### PR TITLE
extract_date_time - 'next {day}' to be 3-9 days in future

### DIFF
--- a/lingua_franca/lang/parse_en.py
+++ b/lingua_franca/lang/parse_en.py
@@ -679,6 +679,10 @@ def extract_datetime_en(string, dateNow, default_time):
     date and the remainder string
        "what is weather forecast".
 
+    The "next" instance of a day or weekend is considered to be no earlier than
+    48 hours in the future. On Friday, "next Monday" would be in 3 days.
+    On Saturday, "next Monday" would be in 9 days.
+
     Args:
         string (str): string containing date words
         dateNow (datetime): A reference date/time for "tommorrow", etc
@@ -885,7 +889,8 @@ def extract_datetime_en(string, dateNow, default_time):
             if dayOffset < 0:
                 dayOffset += 7
             if wordPrev == "next":
-                dayOffset += 7
+                if dayOffset <= 2:
+                    dayOffset += 7
                 used += 1
                 start -= 1
             elif wordPrev == "last":
@@ -1790,7 +1795,8 @@ def annotate_datetime_en(string, dateNow=None, default_time=None):
             if dayOffset < 0:
                 dayOffset += 7
             if wordPrev == "next":
-                dayOffset += 7
+                if dayOffset <= 2:
+                    dayOffset += 7
                 used += 1
                 start -= 1
             elif wordPrev == "last":

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -340,14 +340,18 @@ class TestNormalize(unittest.TestCase):
                     "2022-06-27 00:00:00", "play happy birthday music")
         testExtract("Skype Mom at 12:45 pm next Thursday",
                     "2017-07-06 12:45:00", "skype mom")
+        testExtract("What's the weather next Friday?",
+                    "2017-06-30 00:00:00", "what weather")
+        testExtract("What's the weather next Wednesday?",
+                    "2017-07-05 00:00:00", "what weather")
         testExtract("What's the weather next Thursday?",
                     "2017-07-06 00:00:00", "what weather")
         testExtract("what is the weather next friday morning",
-                    "2017-07-07 08:00:00", "what is weather")
+                    "2017-06-30 08:00:00", "what is weather")
         testExtract("what is the weather next friday evening",
-                    "2017-07-07 19:00:00", "what is weather")
+                    "2017-06-30 19:00:00", "what is weather")
         testExtract("what is the weather next friday afternoon",
-                    "2017-07-07 15:00:00", "what is weather")
+                    "2017-06-30 15:00:00", "what is weather")
         testExtract("remind me to call mom on august 3rd",
                     "2017-08-03 00:00:00", "remind me to call mom")
         testExtract("Buy fireworks on the 4th of July",
@@ -452,9 +456,9 @@ class TestNormalize(unittest.TestCase):
         testExtract("remind me to call mom at 10am this saturday",
                     "2017-07-01 10:00:00", "remind me to call mom")
         testExtract("remind me to call mom at 10 next saturday",
-                    "2017-07-08 10:00:00", "remind me to call mom")
+                    "2017-07-01 10:00:00", "remind me to call mom")
         testExtract("remind me to call mom at 10am next saturday",
-                    "2017-07-08 10:00:00", "remind me to call mom")
+                    "2017-07-01 10:00:00", "remind me to call mom")
         # Below two tests, ensure that time is picked
         # even if no am/pm is specified
         # in case of weekdays/tonight


### PR DESCRIPTION
same as https://github.com/MycroftAI/mycroft-core/pull/2184

    The "next" instance of a day or weekend is considered to be no earlier than
    48 hours in the future. On Friday, "next Monday" would be in 3 days.
    On Saturday, "next Monday" would be in 9 days.

NOTE: this test case is different for some reason, needs investigation https://github.com/MycroftAI/mycroft-core/pull/2184/files#diff-01390ace1c1a3cf68bc710dca7ad532dR359