### PR TITLE
handle extracting "tonight"/"at night"

### DIFF
--- a/lingua_franca/lang/parse_en.py
+++ b/lingua_franca/lang/parse_en.py
@@ -899,6 +899,11 @@ def extract_datetime_en(string, dateNow, default_time):
             if hrAbs is None:
                 hrAbs = 19
             used += 1
+        elif word == "tonight" or word == "night":
+            if hrAbs is None:
+                hrAbs = 22
+            #used += 1 ## NOTE this breaks other tests, TODO refactor me!
+
         # couple of time_unit
         elif word == "2" and wordNext == "of" and \
                 wordNextNext in ["hours", "minutes", "seconds"]:

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -477,6 +477,13 @@ class TestNormalize(unittest.TestCase):
         testExtract("set alarm at 7:30 on weekdays",
                     "2017-06-27 19:30:00", "set alarm on weekdays")
 
+        # TODO this test is imperfect due to "tonight" in the reminder, but let is pass since the date is correct
+        testExtract("lets meet tonight",
+                    "2017-06-27 22:00:00", "lets meet tonight")
+        # TODO this test is imperfect due to "at night" in the reminder, but let is pass since the date is correct
+        testExtract("lets meet later at night",
+                    "2017-06-27 22:00:00", "lets meet later at night")
+
     def test_extract_ambiguous_time_en(self):
         morning = datetime(2017, 6, 27, 8, 1, 2)
         evening = datetime(2017, 6, 27, 20, 1, 2)

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -483,6 +483,12 @@ class TestNormalize(unittest.TestCase):
         # TODO this test is imperfect due to "at night" in the reminder, but let is pass since the date is correct
         testExtract("lets meet later at night",
                     "2017-06-27 22:00:00", "lets meet later at night")
+        # TODO this test is imperfect due to "night" in the reminder, but let is pass since the date is correct
+        testExtract("what's the weather like tomorrow night",
+                    "2017-06-28 22:00:00", "what is weather like night")
+        # TODO this test is imperfect due to "night" in the reminder, but let is pass since the date is correct
+        testExtract("what's the weather like next tuesday night",
+                    "2017-07-04 22:00:00", "what is weather like night")
 
     def test_extract_ambiguous_time_en(self):
         morning = datetime(2017, 6, 27, 8, 1, 2)


### PR DESCRIPTION
partially fixes #7 

this PR makes the extracted date correct and sets it to 22 pm, but the remainder is imperfect

some later code seems to depend on "tonight" being present in the remainder, some code refactor is in order, documented in unittests