### PR TITLE
feat/add nice bytes

### DIFF
--- a/lingua_franca/format.py
+++ b/lingua_franca/format.py
@@ -245,25 +245,47 @@ date_time_format = DateTimeFormat(os.path.join(os.path.dirname(__file__),
                                                'res/text'))
 
 
-def nice_bytes(number, lang=None, speech=True):
+def nice_bytes(number, lang=None, speech=True, binary=True, gnu=False):
+    """
+
+    :param number: number of bytes (int)
+    :param lang: lang_code, ignored for now (str)
+    :param speech: spoken form (True) or short units (False)
+    :param binary: 1 kilobyte = 1024 bytes (True) or 1 kilobyte = 1000 bytes (False)
+    :param gnu: Kilo Byte / KiB (False) vs K Byte / KB (True)
+    :return: nice bytes (str)
+    """
     # Attribution: http://stackoverflow.com/a/1094933/2444609
 
     lang_code = get_primary_lang_code(lang)
-    if not speech:
-        default_units = ['B', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi', 'Yi']
+
+    if speech and gnu:
+        default_units = ['Bytes', 'Kilo', 'Mega', 'Giga', 'Tera', 'Peta', 'Exa', 'Zetta', 'Yotta']
+    elif speech:
+        default_units = ['Bytes', 'Kilo bytes', 'Mega bytes', 'Giga bytes',
+                         'Tera bytes', 'Peta bytes', 'Exa bytes', 'Zetta bytes', 'Yotta bytes']
+    elif gnu:
+        default_units = ['B', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
+    elif binary:
+        default_units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
     else:
-        default_units = ['Bytes', 'Kilo bytes', 'Mega bytes', 'Giga bytes', 'Tera bytes',
-                         'Peta bytes', 'Exa bytes', 'Zetta bytes', 'Yotta bytes']
+        default_units = ['B', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi', 'Yi']
+
     #if lang_code == "XX":
     #    units = ['Bytes', 'Kilo bytes', 'Mega bytes', 'Giga bytes', 'Tera bytes',
     #             'Peta bytes', 'Exa bytes', 'Yotta bytes']
     #else:
     units = default_units
 
+    if binary:
+        n = 1024
+    else:
+        n = 1000
+
     for unit in units[:-1]:
-        if abs(number) < 1024.0:
+        if abs(number) < n:
             return "%3.1f %s" % (number, unit)
-        number /= 1024.0
+        number /= n
 
     return "%.1f %s" % (number, units[-1])
 

--- a/lingua_franca/format.py
+++ b/lingua_franca/format.py
@@ -290,7 +290,7 @@ def nice_bytes(number, lang=None, speech=True, binary=True, gnu=False, places=1)
 
     for unit in units[:-1]:
         if abs(number) < n:
-            if number == 1 and speech:
+            if number == 1 and speech and not gnu:
                 # strip final "s"
                 unit = unit[:-1]
             return "%3.1f %s" % (number, unit)

--- a/lingua_franca/format.py
+++ b/lingua_franca/format.py
@@ -245,14 +245,18 @@ date_time_format = DateTimeFormat(os.path.join(os.path.dirname(__file__),
                                                'res/text'))
 
 
-def nice_bytes(number, lang=None, speech=True, binary=True, gnu=False):
+def nice_bytes(number, lang=None, speech=True, binary=True, gnu=False, places=1):
     """
+    turns a number of bytes into a string using appropriate units
+
+    spoken binary units - https://en.wikipedia.org/wiki/Kibibyte
 
     :param number: number of bytes (int)
     :param lang: lang_code, ignored for now (str)
     :param speech: spoken form (True) or short units (False)
     :param binary: 1 kilobyte = 1024 bytes (True) or 1 kilobyte = 1000 bytes (False)
-    :param gnu: Kilo Byte / KiB (False) vs K Byte / KB (True)
+    :param gnu: say only order of magnitude (bool)  - 100 Kilo (True) or 100 Kilobytes (False)
+    :param places: decimal places (int)
     :return: nice bytes (str)
     """
     # Attribution: http://stackoverflow.com/a/1094933/2444609
@@ -261,6 +265,9 @@ def nice_bytes(number, lang=None, speech=True, binary=True, gnu=False):
 
     if speech and gnu:
         default_units = ['Bytes', 'Kilo', 'Mega', 'Giga', 'Tera', 'Peta', 'Exa', 'Zetta', 'Yotta']
+    elif speech and binary:
+        default_units = ['Bytes', 'Kibibytes', 'Mebibytes', 'Gibibytes',
+                         'Tebibytes', 'Pebibytes', 'Exbibytes', 'Zebibytes', 'Yobibytes']
     elif speech:
         default_units = ['Bytes', 'Kilobytes', 'Megabytes', 'Gigabytes',
                          'Terabytes', 'Petabytes', 'Exabytes', 'Zettabytes', 'Yottabytes']
@@ -269,11 +276,10 @@ def nice_bytes(number, lang=None, speech=True, binary=True, gnu=False):
     elif binary:
         default_units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
     else:
-        default_units = ['B', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi', 'Yi']
+        default_units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
 
     #if lang_code == "XX":
-    #    units = ['Bytes', 'Kilo bytes', 'Mega bytes', 'Giga bytes', 'Tera bytes',
-    #             'Peta bytes', 'Exa bytes', 'Yotta bytes']
+    #    units = ['...']
     #else:
     units = default_units
 

--- a/lingua_franca/format.py
+++ b/lingua_franca/format.py
@@ -249,18 +249,18 @@ def nice_bytes(number, lang=None, speech=True, binary=True, gnu=False, places=1)
     """
     turns a number of bytes into a string using appropriate units
 
+    prefixes - https://en.wikipedia.org/wiki/Binary_prefix
     spoken binary units - https://en.wikipedia.org/wiki/Kibibyte
+    implementation - http://stackoverflow.com/a/1094933/2444609
 
     :param number: number of bytes (int)
     :param lang: lang_code, ignored for now (str)
     :param speech: spoken form (True) or short units (False)
     :param binary: 1 kilobyte = 1024 bytes (True) or 1 kilobyte = 1000 bytes (False)
     :param gnu: say only order of magnitude (bool)  - 100 Kilo (True) or 100 Kilobytes (False)
-    :param places: decimal places (int)
+    :param places: decimal places (int), TODO not yet implemented
     :return: nice bytes (str)
     """
-    # Attribution: http://stackoverflow.com/a/1094933/2444609
-
     lang_code = get_primary_lang_code(lang)
 
     if speech and gnu:

--- a/lingua_franca/format.py
+++ b/lingua_franca/format.py
@@ -63,7 +63,7 @@ def _translate_word(name, lang):
 
     lang_code = get_full_lang_code(lang)
 
-    filename = resolve_resource_file(join("text", lang_code, name+".word"))
+    filename = resolve_resource_file(join("text", lang_code, name + ".word"))
     if filename:
         # open the file
         try:
@@ -141,7 +141,7 @@ class DateTimeFormat:
         x_in_x000 = self.lang_config[lang]['number'].get(str(int(
             number % 10000 / 1000))) or str(int(number % 10000 / 1000))
         x0_in_x000 = self.lang_config[lang]['number'].get(str(int(
-            number % 10000 / 1000)*10)) or str(int(number % 10000 / 1000)*10)
+            number % 10000 / 1000) * 10)) or str(int(number % 10000 / 1000) * 10)
         x_in_0x00 = self.lang_config[lang]['number'].get(str(int(
             number % 1000 / 100)) or str(int(number % 1000 / 100)))
 
@@ -242,7 +242,30 @@ class DateTimeFormat:
 
 
 date_time_format = DateTimeFormat(os.path.join(os.path.dirname(__file__),
-                                  'res/text'))
+                                               'res/text'))
+
+
+def nice_bytes(number, lang=None, speech=True):
+    # Attribution: http://stackoverflow.com/a/1094933/2444609
+
+    lang_code = get_primary_lang_code(lang)
+    if not speech:
+        default_units = ['B', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi', 'Yi']
+    else:
+        default_units = ['Bytes', 'Kilo bytes', 'Mega bytes', 'Giga bytes', 'Tera bytes',
+                         'Peta bytes', 'Exa bytes', 'Zetta bytes', 'Yotta bytes']
+    #if lang_code == "XX":
+    #    units = ['Bytes', 'Kilo bytes', 'Mega bytes', 'Giga bytes', 'Tera bytes',
+    #             'Peta bytes', 'Exa bytes', 'Yotta bytes']
+    #else:
+    units = default_units
+
+    for unit in units[:-1]:
+        if abs(number) < 1024.0:
+            return "%3.1f %s" % (number, unit)
+        number /= 1024.0
+
+    return "%.1f %s" % (number, units[-1])
 
 
 def nice_number(number, lang=None, speech=True, denominators=None):
@@ -520,7 +543,7 @@ def nice_duration(duration, lang=None, speech=True):
             out += str(hours) + ":"
         if minutes < 10 and (hours > 0 or days > 0):
             out += "0"
-        out += str(minutes)+":"
+        out += str(minutes) + ":"
         if seconds < 10:
             out += "0"
         out += str(seconds)

--- a/lingua_franca/format.py
+++ b/lingua_franca/format.py
@@ -262,8 +262,8 @@ def nice_bytes(number, lang=None, speech=True, binary=True, gnu=False):
     if speech and gnu:
         default_units = ['Bytes', 'Kilo', 'Mega', 'Giga', 'Tera', 'Peta', 'Exa', 'Zetta', 'Yotta']
     elif speech:
-        default_units = ['Bytes', 'Kilo bytes', 'Mega bytes', 'Giga bytes',
-                         'Tera bytes', 'Peta bytes', 'Exa bytes', 'Zetta bytes', 'Yotta bytes']
+        default_units = ['Bytes', 'Kilobytes', 'Megabytes', 'Gigabytes',
+                         'Terabytes', 'Petabytes', 'Exabytes', 'Zettabytes', 'Yottabytes']
     elif gnu:
         default_units = ['B', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
     elif binary:
@@ -284,9 +284,11 @@ def nice_bytes(number, lang=None, speech=True, binary=True, gnu=False):
 
     for unit in units[:-1]:
         if abs(number) < n:
+            if number == 1 and speech:
+                # strip final "s"
+                unit = unit[:-1]
             return "%3.1f %s" % (number, unit)
         number /= n
-
     return "%.1f %s" % (number, units[-1])
 
 

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -80,15 +80,49 @@ class TestNiceBytes(unittest.TestCase):
     def test_nice_bytes(self):
         self.assertEqual(nice_bytes(0, speech=False), "0.0 B")
         self.assertEqual(nice_bytes(1000, speech=False), "1000.0 B")
-        self.assertEqual(nice_bytes(1024, speech=False), "1.0 Ki")
-        self.assertEqual(nice_bytes(2000000, speech=False), "1.9 Mi")
-        self.assertEqual(nice_bytes(2000000000, speech=False), "1.9 Gi")
-        self.assertEqual(nice_bytes(2000000000000, speech=False), "1.8 Ti")
-        self.assertEqual(nice_bytes(2000000000000000, speech=False), "1.8 Pi")
-        self.assertEqual(nice_bytes(2000000000000000000, speech=False), "1.7 Ei")
-        self.assertEqual(nice_bytes(2000000000000000000000, speech=False), "1.7 Zi")
-        self.assertEqual(nice_bytes(2000000000000000000000000, speech=False), "1.7 Yi")
-        self.assertEqual(nice_bytes(2000000000000000000000000000, speech=False), "1654.4 Yi")
+        self.assertEqual(nice_bytes(1024, speech=False), "1.0 KiB")
+        self.assertEqual(nice_bytes(2000000, speech=False), "1.9 MiB")
+        self.assertEqual(nice_bytes(2000000000, speech=False), "1.9 GiB")
+        self.assertEqual(nice_bytes(2000000000000, speech=False), "1.8 TiB")
+        self.assertEqual(nice_bytes(2000000000000000, speech=False), "1.8 PiB")
+        self.assertEqual(nice_bytes(2000000000000000000, speech=False), "1.7 EiB")
+        self.assertEqual(nice_bytes(2000000000000000000000, speech=False), "1.7 ZiB")
+        self.assertEqual(nice_bytes(2000000000000000000000000, speech=False), "1.7 YiB")
+        self.assertEqual(nice_bytes(2000000000000000000000000000, speech=False), "1654.4 YiB")
+
+    def test_nice_bytes_gnu(self):
+        self.assertEqual(nice_bytes(0, speech=False, gnu=True), "0.0 B")
+        self.assertEqual(nice_bytes(1000, speech=False, gnu=True), "1000.0 B")
+        self.assertEqual(nice_bytes(1024, speech=False, gnu=True), "1.0 K")
+        self.assertEqual(nice_bytes(2000000, speech=False, gnu=True), "1.9 M")
+        self.assertEqual(nice_bytes(2000000000, speech=False, gnu=True), "1.9 G")
+        self.assertEqual(nice_bytes(2000000000000, speech=False, gnu=True), "1.8 T")
+        self.assertEqual(nice_bytes(2000000000000000, speech=False, gnu=True), "1.8 P")
+        self.assertEqual(nice_bytes(2000000000000000000, speech=False, gnu=True), "1.7 E")
+        self.assertEqual(nice_bytes(2000000000000000000000, speech=False, gnu=True), "1.7 Z")
+        self.assertEqual(nice_bytes(2000000000000000000000000, speech=False, gnu=True), "1.7 Y")
+        self.assertEqual(nice_bytes(2000000000000000000000000000, speech=False, gnu=True), "1654.4 Y")
+
+        self.assertEqual(nice_bytes(2000000, gnu=True), "1.9 Mega")
+        self.assertEqual(nice_bytes(2000000000, gnu=True), "1.9 Giga")
+        self.assertEqual(nice_bytes(2000000000000, gnu=True), "1.8 Tera")
+
+    def test_nice_bytes_non_binary(self):
+        self.assertEqual(nice_bytes(0, speech=False, binary=False), "0.0 B")
+        self.assertEqual(nice_bytes(1000, speech=False, binary=False), "1.0 Ki")
+        self.assertEqual(nice_bytes(1024, speech=False, binary=False), "1.0 Ki")
+        self.assertEqual(nice_bytes(2000000, speech=False, binary=False), "2.0 Mi")
+        self.assertEqual(nice_bytes(2000000000, speech=False, binary=False), "2.0 Gi")
+        self.assertEqual(nice_bytes(2000000000000, speech=False, binary=False), "2.0 Ti")
+        self.assertEqual(nice_bytes(2000000000000000, speech=False, binary=False), "2.0 Pi")
+        self.assertEqual(nice_bytes(2000000000000000000, speech=False, binary=False), "2.0 Ei")
+        self.assertEqual(nice_bytes(2000000000000000000000, speech=False, binary=False), "2.0 Zi")
+        self.assertEqual(nice_bytes(2000000000000000000000000, speech=False, binary=False), "2.0 Yi")
+        self.assertEqual(nice_bytes(2000000000000000000000000000, speech=False, binary=False), "2000.0 Yi")
+
+        self.assertEqual(nice_bytes(2000000, binary=False), "2.0 Mega bytes")
+        self.assertEqual(nice_bytes(2000000000, binary=False), "2.0 Giga bytes")
+        self.assertEqual(nice_bytes(2000000000000, binary=False), "2.0 Tera bytes")
 
 
 class TestNiceNumberFormat(unittest.TestCase):

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -63,20 +63,48 @@ NUMBERS_FIXTURE_EN = {
 
 
 class TestNiceBytes(unittest.TestCase):
+
+    def test_nice_bytes_non_binary_speech(self):
+        self.assertEqual(nice_bytes(0, binary=False), "0.0 Bytes")
+        self.assertEqual(nice_bytes(1, binary=False), "1.0 Byte")
+        self.assertEqual(nice_bytes(1000, binary=False), "1.0 Kilobyte")
+        self.assertEqual(nice_bytes(2000000, binary=False), "2.0 Megabytes")
+        self.assertEqual(nice_bytes(2000000000, binary=False), "2.0 Gigabytes")
+        self.assertEqual(nice_bytes(2000000000000, binary=False), "2.0 Terabytes")
+        self.assertEqual(nice_bytes(2000000000000000, binary=False), "2.0 Petabytes")
+        self.assertEqual(nice_bytes(2000000000000000000, binary=False), "2.0 Exabytes")
+        self.assertEqual(nice_bytes(2000000000000000000000, binary=False), "2.0 Zettabytes")
+        self.assertEqual(nice_bytes(2000000000000000000000000, binary=False), "2.0 Yottabytes")
+        self.assertEqual(nice_bytes(2000000000000000000000000000, binary=False), "2000.0 Yottabytes")
+
+    def test_nice_bytes_non_binary(self):
+        self.assertEqual(nice_bytes(0, speech=False, binary=False), "0.0 B")
+        self.assertEqual(nice_bytes(1000, speech=False, binary=False), "1.0 KB")
+        self.assertEqual(nice_bytes(1024, speech=False, binary=False), "1.0 KB")
+        self.assertEqual(nice_bytes(2000000, speech=False, binary=False), "2.0 MB")
+        self.assertEqual(nice_bytes(2000000000, speech=False, binary=False), "2.0 GB")
+        self.assertEqual(nice_bytes(2000000000000, speech=False, binary=False), "2.0 TB")
+        self.assertEqual(nice_bytes(2000000000000000, speech=False, binary=False), "2.0 PB")
+        self.assertEqual(nice_bytes(2000000000000000000, speech=False, binary=False), "2.0 EB")
+        self.assertEqual(nice_bytes(2000000000000000000000, speech=False, binary=False), "2.0 ZB")
+        self.assertEqual(nice_bytes(2000000000000000000000000, speech=False, binary=False), "2.0 YB")
+        self.assertEqual(nice_bytes(2000000000000000000000000000, speech=False, binary=False), "2000.0 YB")
+
     def test_nice_bytes_speech(self):
+        # https://en.wikipedia.org/wiki/Kibibyte
         self.assertEqual(nice_bytes(0), "0.0 Bytes")
         self.assertEqual(nice_bytes(1), "1.0 Byte")
         self.assertEqual(nice_bytes(1000), "1000.0 Bytes")
-        self.assertEqual(nice_bytes(1024), "1.0 Kilobyte")
-        self.assertEqual(nice_bytes(2000000), "1.9 Megabytes")
-        self.assertEqual(nice_bytes(2000000000), "1.9 Gigabytes")
-        self.assertEqual(nice_bytes(2000000000000), "1.8 Terabytes")
-        self.assertEqual(nice_bytes(2000000000000000), "1.8 Petabytes")
-        self.assertEqual(nice_bytes(2000000000000000000), "1.7 Exabytes")
-        self.assertEqual(nice_bytes(2000000000000000000000), "1.7 Zettabytes")
-        self.assertEqual(nice_bytes(2000000000000000000000000), "1.7 Yottabytes")
-        # no more named prefixes - https://en.wikipedia.org/wiki/Binary_prefix#Specific_units_of_IEC_60027-2_A.2_and_ISO.2FIEC_80000
-        self.assertEqual(nice_bytes(2000000000000000000000000000), "1654.4 Yottabytes")
+        self.assertEqual(nice_bytes(1024), "1.0 Kibibyte")
+        self.assertEqual(nice_bytes(2000000), "1.9 Mebibytes")
+        self.assertEqual(nice_bytes(2000000000), "1.9 Gibibytes")
+        self.assertEqual(nice_bytes(2000000000000), "1.8 Tebibytes")
+        self.assertEqual(nice_bytes(2000000000000000), "1.8 Pebibytes")
+        self.assertEqual(nice_bytes(2000000000000000000), "1.7 Exbibytes")
+        self.assertEqual(nice_bytes(2000000000000000000000), "1.7 Zebibytes")
+        self.assertEqual(nice_bytes(2000000000000000000000000), "1.7 Yobibytes")
+        # no more named prefixes - https://en.wikipedia.org/wiki/Binary_prefix#Specific_uni
+        self.assertEqual(nice_bytes(2000000000000000000000000000), "1654.4 Yobibytes")
 
     def test_nice_bytes(self):
         self.assertEqual(nice_bytes(0, speech=False), "0.0 B")
@@ -92,6 +120,10 @@ class TestNiceBytes(unittest.TestCase):
         self.assertEqual(nice_bytes(2000000000000000000000000000, speech=False), "1654.4 YiB")
 
     def test_nice_bytes_gnu(self):
+        self.assertEqual(nice_bytes(2000000, gnu=True), "1.9 Mega")
+        self.assertEqual(nice_bytes(2000000000, gnu=True), "1.9 Giga")
+        self.assertEqual(nice_bytes(2000000000000, gnu=True), "1.8 Tera")
+
         self.assertEqual(nice_bytes(0, speech=False, gnu=True), "0.0 B")
         self.assertEqual(nice_bytes(1000, speech=False, gnu=True), "1000.0 B")
         self.assertEqual(nice_bytes(1024, speech=False, gnu=True), "1.0 K")
@@ -103,27 +135,6 @@ class TestNiceBytes(unittest.TestCase):
         self.assertEqual(nice_bytes(2000000000000000000000, speech=False, gnu=True), "1.7 Z")
         self.assertEqual(nice_bytes(2000000000000000000000000, speech=False, gnu=True), "1.7 Y")
         self.assertEqual(nice_bytes(2000000000000000000000000000, speech=False, gnu=True), "1654.4 Y")
-
-        self.assertEqual(nice_bytes(2000000, gnu=True), "1.9 Mega")
-        self.assertEqual(nice_bytes(2000000000, gnu=True), "1.9 Giga")
-        self.assertEqual(nice_bytes(2000000000000, gnu=True), "1.8 Tera")
-
-    def test_nice_bytes_non_binary(self):
-        self.assertEqual(nice_bytes(0, speech=False, binary=False), "0.0 B")
-        self.assertEqual(nice_bytes(1000, speech=False, binary=False), "1.0 Ki")
-        self.assertEqual(nice_bytes(1024, speech=False, binary=False), "1.0 Ki")
-        self.assertEqual(nice_bytes(2000000, speech=False, binary=False), "2.0 Mi")
-        self.assertEqual(nice_bytes(2000000000, speech=False, binary=False), "2.0 Gi")
-        self.assertEqual(nice_bytes(2000000000000, speech=False, binary=False), "2.0 Ti")
-        self.assertEqual(nice_bytes(2000000000000000, speech=False, binary=False), "2.0 Pi")
-        self.assertEqual(nice_bytes(2000000000000000000, speech=False, binary=False), "2.0 Ei")
-        self.assertEqual(nice_bytes(2000000000000000000000, speech=False, binary=False), "2.0 Zi")
-        self.assertEqual(nice_bytes(2000000000000000000000000, speech=False, binary=False), "2.0 Yi")
-        self.assertEqual(nice_bytes(2000000000000000000000000000, speech=False, binary=False), "2000.0 Yi")
-
-        self.assertEqual(nice_bytes(2000000, binary=False), "2.0 Megabytes")
-        self.assertEqual(nice_bytes(2000000000, binary=False), "2.0 Gigabytes")
-        self.assertEqual(nice_bytes(2000000000000, binary=False), "2.0 Terabytes")
 
 
 class TestNiceNumberFormat(unittest.TestCase):

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -29,6 +29,7 @@ from lingua_franca.format import nice_duration
 from lingua_franca.format import pronounce_number
 from lingua_franca.format import date_time_format
 from lingua_franca.format import join_list
+from lingua_franca.format import nice_bytes
 
 NUMBERS_FIXTURE_EN = {
     1.435634: '1.436',
@@ -59,6 +60,35 @@ NUMBERS_FIXTURE_EN = {
     7.421: '7 and 8 nineteenths',
     0.05: 'a twentyith'
 }
+
+
+class TestNiceBytes(unittest.TestCase):
+    def test_nice_bytes_speech(self):
+        self.assertEqual(nice_bytes(0), "0.0 Bytes")
+        self.assertEqual(nice_bytes(1000), "1000.0 Bytes")
+        self.assertEqual(nice_bytes(1024), "1.0 Kilo bytes")
+        self.assertEqual(nice_bytes(2000000), "1.9 Mega bytes")
+        self.assertEqual(nice_bytes(2000000000), "1.9 Giga bytes")
+        self.assertEqual(nice_bytes(2000000000000), "1.8 Tera bytes")
+        self.assertEqual(nice_bytes(2000000000000000), "1.8 Peta bytes")
+        self.assertEqual(nice_bytes(2000000000000000000), "1.7 Exa bytes")
+        self.assertEqual(nice_bytes(2000000000000000000000), "1.7 Zetta bytes")
+        self.assertEqual(nice_bytes(2000000000000000000000000), "1.7 Yotta bytes")
+        # no more named prefixes - https://en.wikipedia.org/wiki/Binary_prefix#Specific_units_of_IEC_60027-2_A.2_and_ISO.2FIEC_80000
+        self.assertEqual(nice_bytes(2000000000000000000000000000), "1654.4 Yotta bytes")
+
+    def test_nice_bytes(self):
+        self.assertEqual(nice_bytes(0, speech=False), "0.0 B")
+        self.assertEqual(nice_bytes(1000, speech=False), "1000.0 B")
+        self.assertEqual(nice_bytes(1024, speech=False), "1.0 Ki")
+        self.assertEqual(nice_bytes(2000000, speech=False), "1.9 Mi")
+        self.assertEqual(nice_bytes(2000000000, speech=False), "1.9 Gi")
+        self.assertEqual(nice_bytes(2000000000000, speech=False), "1.8 Ti")
+        self.assertEqual(nice_bytes(2000000000000000, speech=False), "1.8 Pi")
+        self.assertEqual(nice_bytes(2000000000000000000, speech=False), "1.7 Ei")
+        self.assertEqual(nice_bytes(2000000000000000000000, speech=False), "1.7 Zi")
+        self.assertEqual(nice_bytes(2000000000000000000000000, speech=False), "1.7 Yi")
+        self.assertEqual(nice_bytes(2000000000000000000000000000, speech=False), "1654.4 Yi")
 
 
 class TestNiceNumberFormat(unittest.TestCase):
@@ -419,7 +449,7 @@ class TestNiceDateFormat(unittest.TestCase):
                 self.assertTrue(len(nice_year(dt, lang=lang)) > 0)
                 # Looking through the date sequence can be helpful
 
-#                print(nice_year(dt, lang=lang))
+    #                print(nice_year(dt, lang=lang))
 
     def test_nice_duration(self):
         self.assertEqual(nice_duration(1), "one second")

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -65,17 +65,18 @@ NUMBERS_FIXTURE_EN = {
 class TestNiceBytes(unittest.TestCase):
     def test_nice_bytes_speech(self):
         self.assertEqual(nice_bytes(0), "0.0 Bytes")
+        self.assertEqual(nice_bytes(1), "1.0 Byte")
         self.assertEqual(nice_bytes(1000), "1000.0 Bytes")
-        self.assertEqual(nice_bytes(1024), "1.0 Kilo bytes")
-        self.assertEqual(nice_bytes(2000000), "1.9 Mega bytes")
-        self.assertEqual(nice_bytes(2000000000), "1.9 Giga bytes")
-        self.assertEqual(nice_bytes(2000000000000), "1.8 Tera bytes")
-        self.assertEqual(nice_bytes(2000000000000000), "1.8 Peta bytes")
-        self.assertEqual(nice_bytes(2000000000000000000), "1.7 Exa bytes")
-        self.assertEqual(nice_bytes(2000000000000000000000), "1.7 Zetta bytes")
-        self.assertEqual(nice_bytes(2000000000000000000000000), "1.7 Yotta bytes")
+        self.assertEqual(nice_bytes(1024), "1.0 Kilobyte")
+        self.assertEqual(nice_bytes(2000000), "1.9 Megabytes")
+        self.assertEqual(nice_bytes(2000000000), "1.9 Gigabytes")
+        self.assertEqual(nice_bytes(2000000000000), "1.8 Terabytes")
+        self.assertEqual(nice_bytes(2000000000000000), "1.8 Petabytes")
+        self.assertEqual(nice_bytes(2000000000000000000), "1.7 Exabytes")
+        self.assertEqual(nice_bytes(2000000000000000000000), "1.7 Zettabytes")
+        self.assertEqual(nice_bytes(2000000000000000000000000), "1.7 Yottabytes")
         # no more named prefixes - https://en.wikipedia.org/wiki/Binary_prefix#Specific_units_of_IEC_60027-2_A.2_and_ISO.2FIEC_80000
-        self.assertEqual(nice_bytes(2000000000000000000000000000), "1654.4 Yotta bytes")
+        self.assertEqual(nice_bytes(2000000000000000000000000000), "1654.4 Yottabytes")
 
     def test_nice_bytes(self):
         self.assertEqual(nice_bytes(0, speech=False), "0.0 B")
@@ -120,9 +121,9 @@ class TestNiceBytes(unittest.TestCase):
         self.assertEqual(nice_bytes(2000000000000000000000000, speech=False, binary=False), "2.0 Yi")
         self.assertEqual(nice_bytes(2000000000000000000000000000, speech=False, binary=False), "2000.0 Yi")
 
-        self.assertEqual(nice_bytes(2000000, binary=False), "2.0 Mega bytes")
-        self.assertEqual(nice_bytes(2000000000, binary=False), "2.0 Giga bytes")
-        self.assertEqual(nice_bytes(2000000000000, binary=False), "2.0 Tera bytes")
+        self.assertEqual(nice_bytes(2000000, binary=False), "2.0 Megabytes")
+        self.assertEqual(nice_bytes(2000000000, binary=False), "2.0 Gigabytes")
+        self.assertEqual(nice_bytes(2000000000000, binary=False), "2.0 Terabytes")
 
 
 class TestNiceNumberFormat(unittest.TestCase):

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -75,6 +75,7 @@ class TestNiceBytes(unittest.TestCase):
         self.assertEqual(nice_bytes(2000000000000000000, binary=False), "2.0 Exabytes")
         self.assertEqual(nice_bytes(2000000000000000000000, binary=False), "2.0 Zettabytes")
         self.assertEqual(nice_bytes(2000000000000000000000000, binary=False), "2.0 Yottabytes")
+        # no more named prefixes after Y - https://en.wikipedia.org/wiki/Binary_prefix
         self.assertEqual(nice_bytes(2000000000000000000000000000, binary=False), "2000.0 Yottabytes")
 
     def test_nice_bytes_non_binary(self):
@@ -88,6 +89,7 @@ class TestNiceBytes(unittest.TestCase):
         self.assertEqual(nice_bytes(2000000000000000000, speech=False, binary=False), "2.0 EB")
         self.assertEqual(nice_bytes(2000000000000000000000, speech=False, binary=False), "2.0 ZB")
         self.assertEqual(nice_bytes(2000000000000000000000000, speech=False, binary=False), "2.0 YB")
+        # no more named prefixes after Y - https://en.wikipedia.org/wiki/Binary_prefix
         self.assertEqual(nice_bytes(2000000000000000000000000000, speech=False, binary=False), "2000.0 YB")
 
     def test_nice_bytes_speech(self):
@@ -103,7 +105,7 @@ class TestNiceBytes(unittest.TestCase):
         self.assertEqual(nice_bytes(2000000000000000000), "1.7 Exbibytes")
         self.assertEqual(nice_bytes(2000000000000000000000), "1.7 Zebibytes")
         self.assertEqual(nice_bytes(2000000000000000000000000), "1.7 Yobibytes")
-        # no more named prefixes - https://en.wikipedia.org/wiki/Binary_prefix#Specific_uni
+        # no more named prefixes after Y - https://en.wikipedia.org/wiki/Binary_prefix
         self.assertEqual(nice_bytes(2000000000000000000000000000), "1654.4 Yobibytes")
 
     def test_nice_bytes(self):
@@ -117,6 +119,7 @@ class TestNiceBytes(unittest.TestCase):
         self.assertEqual(nice_bytes(2000000000000000000, speech=False), "1.7 EiB")
         self.assertEqual(nice_bytes(2000000000000000000000, speech=False), "1.7 ZiB")
         self.assertEqual(nice_bytes(2000000000000000000000000, speech=False), "1.7 YiB")
+        # no more named prefixes after Y - https://en.wikipedia.org/wiki/Binary_prefix
         self.assertEqual(nice_bytes(2000000000000000000000000000, speech=False), "1654.4 YiB")
 
     def test_nice_bytes_gnu(self):
@@ -135,7 +138,13 @@ class TestNiceBytes(unittest.TestCase):
         self.assertEqual(nice_bytes(2000000000000000000, speech=False, gnu=True), "1.7 E")
         self.assertEqual(nice_bytes(2000000000000000000000, speech=False, gnu=True), "1.7 Z")
         self.assertEqual(nice_bytes(2000000000000000000000000, speech=False, gnu=True), "1.7 Y")
+        # no more named prefixes after Y - https://en.wikipedia.org/wiki/Binary_prefix
         self.assertEqual(nice_bytes(2000000000000000000000000000, speech=False, gnu=True), "1654.4 Y")
+
+        self.assertEqual(nice_bytes(2000000, gnu=True, binary=False), "2.0 Mega")
+        self.assertEqual(nice_bytes(2000000000, gnu=True, binary=False), "2.0 Giga")
+        self.assertEqual(nice_bytes(2000000, speech=False, gnu=True, binary=False), "2.0 M")
+        self.assertEqual(nice_bytes(2000000000, speech=False, gnu=True, binary=False), "2.0 G")
 
 
 class TestNiceNumberFormat(unittest.TestCase):

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -120,6 +120,7 @@ class TestNiceBytes(unittest.TestCase):
         self.assertEqual(nice_bytes(2000000000000000000000000000, speech=False), "1654.4 YiB")
 
     def test_nice_bytes_gnu(self):
+        self.assertEqual(nice_bytes(1024, gnu=True), "1.0 Kilo")
         self.assertEqual(nice_bytes(2000000, gnu=True), "1.9 Mega")
         self.assertEqual(nice_bytes(2000000000, gnu=True), "1.9 Giga")
         self.assertEqual(nice_bytes(2000000000000, gnu=True), "1.8 Tera")


### PR DESCRIPTION
adds a utility function, `nice_bytes`

converts a number of bytes into a spoken form or unit form, handles all prefixes

```python
nice_bytes(1024) == "1.0 Kilo bytes"
nice_bytes(1024, speech=False) == "1.0 Ki"
```

# TODO
configurable number of decimal places