### PR TITLE
Bugfix/extract datetime bugs

### DIFF
--- a/lingua_franca/lang/parse_en.py
+++ b/lingua_franca/lang/parse_en.py
@@ -714,7 +714,7 @@ def extract_datetime_en(string, dateNow, default_time):
               wordNext == "after" and
               wordNextNext == "tomorrow" and
               not fromFlag and
-              not wordPrev[0].isdigit()):
+              (not wordPrev or not wordPrev[0].isdigit())):
             dayOffset = 2
             used = 3
             if wordPrev == "the":
@@ -722,11 +722,11 @@ def extract_datetime_en(string, dateNow, default_time):
                 used += 1
                 # parse 5 days, 10 weeks, last week, next week
         elif word == "day":
-            if wordPrev[0].isdigit():
+            if wordPrev and wordPrev[0].isdigit():
                 dayOffset += int(wordPrev)
                 start -= 1
                 used = 2
-        elif word == "week" and not fromFlag:
+        elif word == "week" and not fromFlag and wordPrev:
             if wordPrev[0].isdigit():
                 dayOffset += int(wordPrev) * 7
                 start -= 1
@@ -740,7 +740,7 @@ def extract_datetime_en(string, dateNow, default_time):
                 start -= 1
                 used = 2
                 # parse 10 months, next month, last month
-        elif word == "month" and not fromFlag:
+        elif word == "month" and not fromFlag and wordPrev:
             if wordPrev[0].isdigit():
                 monthOffset = int(wordPrev)
                 start -= 1
@@ -754,7 +754,7 @@ def extract_datetime_en(string, dateNow, default_time):
                 start -= 1
                 used = 2
         # parse 5 years, next year, last year
-        elif word == "year" and not fromFlag:
+        elif word == "year" and not fromFlag and wordPrev:
             if wordPrev[0].isdigit():
                 yearOffset = int(wordPrev)
                 start -= 1

--- a/lingua_franca/lang/parse_en.py
+++ b/lingua_franca/lang/parse_en.py
@@ -825,6 +825,7 @@ def extract_datetime_en(string, dateNow, default_time):
         validFollowups.append("next")
         validFollowups.append("last")
         validFollowups.append("now")
+        validFollowups.append("this")
         if (word == "from" or word == "after") and wordNext in validFollowups:
             used = 2
             fromFlag = True

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -252,6 +252,8 @@ class TestNormalize(unittest.TestCase):
                     "2017-06-27 13:34:00", "set ambush")
         testExtract("Set the ambush for 5 days from today",
                     "2017-07-02 00:00:00", "set ambush")
+        testExtract("day after tomorrow",
+                    "2017-06-29 00:00:00", "")
         testExtract("What is the day after tomorrow's weather?",
                     "2017-06-29 00:00:00", "what is weather")
         testExtract("Remind me at 10:45 pm",
@@ -485,6 +487,14 @@ class TestNormalize(unittest.TestCase):
         noonish = datetime(2017, 6, 27, 12, 1, 2)
         self.assertEqual(
             extract_datetime('feed the fish'), None)
+        self.assertEqual(
+            extract_datetime('day'), None)
+        self.assertEqual(
+            extract_datetime('week'), None)
+        self.assertEqual(
+            extract_datetime('month'), None)
+        self.assertEqual(
+            extract_datetime('year'), None)
         self.assertEqual(
             extract_datetime(' '), None)
         self.assertEqual(

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -330,6 +330,8 @@ class TestNormalize(unittest.TestCase):
                     "2017-06-27 13:19:00", "remind me to call mom")
         testExtract("remind me to call mom in a quarter of an hour",
                     "2017-06-27 13:19:00", "remind me to call mom")
+        testExtract("remind me to call mom at 10am 2 days after this saturday",
+                    "2017-07-03 10:00:00", "remind me to call mom")
         testExtract("Play Rick Astley music 2 days from Friday",
                     "2017-07-02 00:00:00", "play rick astley music")
         testExtract("Begin the invasion at 3:45 pm on Thursday",


### PR DESCRIPTION
check unittests for edge cases handled

fixes syntax error when trying to access wordPrev first digit but wordPrev is an empty string

fix "after/from this weekday"  ("this" not currently handled) - possibly related to https://github.com/MycroftAI/mycroft-core/issues/2369


