### PR TITLE
Remove Python 3.4 from autotest and add Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ install:
   - pip install -r requirements.txt
 # command to run tests
 script:
-  - pytest
+  - pytest test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ branches:
     - dev
 language: python
 python:
-  - "3.4"
   - "3.5"
-  - "3.6"      # current default Python on Travis CI
+  - "3.6"
   - "3.7"
+  - "3.8"
 # command to install dependencies
 install:
   - pip install -r requirements.txt


### PR DESCRIPTION
This removes the old python 3.4 version from the test suite and adds python 3.8. It also updates the pytest command to only scan the test folder for tests.