### PR TITLE
Add logic to normalize comma-delimited decimals

### DIFF
--- a/lingua_franca/parse.py
+++ b/lingua_franca/parse.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 from difflib import SequenceMatcher
+import re
+
 from lingua_franca.time import now_local
 from lingua_franca.lang import get_primary_lang_code
 
@@ -93,6 +95,13 @@ def extract_numbers(text, short_scale=True, ordinals=False, lang=None):
     Returns:
         list: list of extracted numbers as floats, or empty list if none found
     """
+    # Replace decimal commas with decimal periods so Python can floatify them
+    sanitize_decimals = re.compile(r".*\d+,{1}\d+")
+    match = sanitize_decimals.match(text)
+    while match:
+        text = text.replace(match[0], match[0].replace(',', '.'))
+        match = sanitize_decimals.match(text)
+
     lang_code = get_primary_lang_code(lang)
     if lang_code == "en":
         return extract_numbers_en(text, short_scale, ordinals)

--- a/test/test_parse_es.py
+++ b/test/test_parse_es.py
@@ -118,7 +118,7 @@ class TestDatetime_es(unittest.TestCase):
     def test_datetime_by_date_es(self):
         # test currentDate==None
         _now = datetime.now()
-        relative_year = _now.year if _now.day <= 11 else (_now.year + 1)
+        relative_year = _now.year if _now.day < 11 else (_now.year + 1)
         self.assertEqual(extract_datetime_es("11 ene")[0],
                          datetime(relative_year, 1, 11))
 


### PR DESCRIPTION
Closes #65 

*All* languages, including English, will now normalize `34,5` to `34.5` before beginning to extract numbers.