### PR TITLE
fix: extractnumber_xx API incompatibility

### DIFF
--- a/lingua_franca/lang/parse_da.py
+++ b/lingua_franca/lang/parse_da.py
@@ -153,10 +153,7 @@ def extractnumber_da(text, short_scale=True, ordinals=False):
 
         break
 
-    if not val:
-        return False
-
-    return val
+    return val or False
 
 
 def extract_datetime_da(string, currentDate, default_time):

--- a/lingua_franca/lang/parse_da.py
+++ b/lingua_franca/lang/parse_da.py
@@ -72,8 +72,10 @@ da_numbers = {
     'million': 1000000
 }
 
-
-def extractnumber_da(text):
+# TODO: short_scale and ordinals don't do anything here.
+# The parameters are present in the function signature for API compatibility
+# reasons.
+def extractnumber_da(text, short_scale=True, ordinals=False):
     """
     This function prepares the given text for parsing by making
     numbers consistent, getting rid of contractions, etc.

--- a/lingua_franca/lang/parse_de.py
+++ b/lingua_franca/lang/parse_de.py
@@ -158,10 +158,7 @@ def extractnumber_de(text, short_scale=True, ordinals=False):
 
         break
 
-    if not val:
-        return False
-
-    return val
+    return val or False
 
 
 def extract_datetime_de(string, currentDate, default_time):

--- a/lingua_franca/lang/parse_de.py
+++ b/lingua_franca/lang/parse_de.py
@@ -77,8 +77,10 @@ de_numbers = {
     'million': 1000000
 }
 
-
-def extractnumber_de(text):
+# TODO: short_scale and ordinals don't do anything here.
+# The parameters are present in the function signature for API compatibility
+# reasons.
+def extractnumber_de(text, short_scale=True, ordinals=False):
     """
     This function prepares the given text for parsing by making
     numbers consistent, getting rid of contractions, etc.

--- a/lingua_franca/lang/parse_fr.py
+++ b/lingua_franca/lang/parse_fr.py
@@ -370,8 +370,10 @@ def number_ordinal_fr(words, i):
 
     return None
 
-
-def extractnumber_fr(text):
+# TODO: short_scale and ordinals don't do anything here.
+# The parameters are present in the function signature for API compatibility
+# reasons.
+def extractnumber_fr(text, short_scale=True, ordinals=False):
     """Takes in a string and extracts a number.
     Args:
         text (str): the string to extract a number from
@@ -467,7 +469,7 @@ def extractnumber_fr(text):
 
     # if result == False:
     if not result:
-        return normalize_fr(text, True)
+        return False
 
     return result
 

--- a/lingua_franca/lang/parse_fr.py
+++ b/lingua_franca/lang/parse_fr.py
@@ -467,11 +467,7 @@ def extractnumber_fr(text, short_scale=True, ordinals=False):
             else:
                 result = val
 
-    # if result == False:
-    if not result:
-        return False
-
-    return result
+    return result or False
 
 
 def extract_datetime_fr(string, currentDate, default_time):

--- a/lingua_franca/lang/parse_pt.py
+++ b/lingua_franca/lang/parse_pt.py
@@ -63,8 +63,10 @@ def isFractional_pt(input_str):
 
     return False
 
-
-def extractnumber_pt(text):
+# TODO: short_scale and ordinals don't do anything here.
+# The parameters are present in the function signature for API compatibility
+# reasons.
+def extractnumber_pt(text, short_scale=True, ordinals=False):
     """
     This function prepares the given text for parsing by making
     numbers consistent, getting rid of contractions, etc.

--- a/lingua_franca/lang/parse_sv.py
+++ b/lingua_franca/lang/parse_sv.py
@@ -17,8 +17,10 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from .parse_common import is_numeric, look_for_fractions
 
-
-def extractnumber_sv(text):
+# TODO: short_scale and ordinals don't do anything here.
+# The parameters are present in the function signature for API compatibility
+# reasons.
+def extractnumber_sv(text, short_scale=True, ordinals=False):
     """
     This function prepares the given text for parsing by making
     numbers consistent, getting rid of contractions, etc.

--- a/lingua_franca/lang/parse_sv.py
+++ b/lingua_franca/lang/parse_sv.py
@@ -119,10 +119,7 @@ def extractnumber_sv(text, short_scale=True, ordinals=False):
 
         break
 
-    if not val:
-        return False
-
-    return val
+    return val or False
 
 
 def extract_datetime_sv(string, currentDate, default_time):

--- a/test/test_parse_fr.py
+++ b/test/test_parse_fr.py
@@ -71,8 +71,7 @@ class TestNormalize_fr(unittest.TestCase):
                          2.02)
         self.assertEqual(extract_number("ça fait virgule 2 cm", lang="fr-fr"),
                          0.2)
-        self.assertEqual(extract_number("point du tout", lang="fr-fr"),
-                         "point tout")
+        self.assertEqual(extract_number("point du tout", lang="fr-fr"), False)
         self.assertEqual(extract_number("32.00 secondes", lang="fr-fr"), 32)
         self.assertEqual(extract_number("mange trente-et-une bougies",
                                         lang="fr-fr"), 31)


### PR DESCRIPTION
For some languages, the definition of `extractnumber_xx` was incompatible with the use of `extract_numbers_generic` since it lacks `short_scale` and `ordinals` keyword args.

This PR fix this.

It also updates the `extractnumber_fr` when no number has been found on the given text by returning `False` instead of a normalized string to make it in sync with all other `extractnumber_xx` methods in other languages which return a number or False if no number has been parsed. Doing so handle cases such as `extractnumbers('2 heures')` which failed otherwise.