### PR TITLE
fix #75 pronounce_number fails on num < 1.0

### DIFF
--- a/lingua_franca/lang/format_en.py
+++ b/lingua_franca/lang/format_en.py
@@ -290,8 +290,8 @@ def pronounce_number_en(num, places=2, short_scale=True, scientific=False,
         return pronounce_number_en(num, places, short_scale, scientific=True)
     # Deal with fractional part
     elif not num == int(num) and places > 0:
-        if num < 1.0 and not result:
-            result = "zero"
+        if abs(num) < 1.0 and (result is "minus " or not result):
+            result += "zero"
         result += " point"
         _num_str = str(num)
         _num_str = _num_str.split(".")[1][0:places]

--- a/lingua_franca/lang/format_en.py
+++ b/lingua_franca/lang/format_en.py
@@ -290,6 +290,8 @@ def pronounce_number_en(num, places=2, short_scale=True, scientific=False,
         return pronounce_number_en(num, places, short_scale, scientific=True)
     # Deal with fractional part
     elif not num == int(num) and places > 0:
+        if num < 1.0 and not result:
+            result = "zero"
         result += " point"
         _num_str = str(num)
         _num_str = _num_str.split(".")[1][0:places]

--- a/lingua_franca/lang/format_en.py
+++ b/lingua_franca/lang/format_en.py
@@ -97,18 +97,19 @@ def pronounce_number_en(num, places=2, short_scale=True, scientific=False,
                 # handling since each call disables the scientific flag
                 return '{}{} times ten to the {}{} power'.format(
                     'negative ' if float(n) < 0 else '',
-                    pronounce_number_en(abs(float(n)), places, short_scale, False, ordinals=False),
+                    pronounce_number_en(
+                        abs(float(n)), places, short_scale, False, ordinals=False),
                     'negative ' if power < 0 else '',
-                    pronounce_number_en(abs(power), places, short_scale, False,ordinals=True))
+                    pronounce_number_en(abs(power), places, short_scale, False, ordinals=True))
             else:
                 # This handles negatives of powers separately from the normal
                 # handling since each call disables the scientific flag
                 return '{}{} times ten to the power of {}{}'.format(
                     'negative ' if float(n) < 0 else '',
-                    pronounce_number_en(abs(float(n)), places, short_scale, False),
+                    pronounce_number_en(
+                        abs(float(n)), places, short_scale, False),
                     'negative ' if power < 0 else '',
                     pronounce_number_en(abs(power), places, short_scale, False))
-
 
     if short_scale:
         number_names = _NUM_STRING_EN.copy()
@@ -290,11 +291,10 @@ def pronounce_number_en(num, places=2, short_scale=True, scientific=False,
     # Deal with fractional part
     elif not num == int(num) and places > 0:
         result += " point"
-        place = 10
-        while int(num * place) % 10 > 0 and places > 0:
-            result += " " + number_names[int(num * place) % 10]
-            place *= 10
-            places -= 1
+        _num_str = str(num)
+        _num_str = _num_str.split(".")[1][0:places]
+        for char in _num_str:
+            result += " " + number_names[int(char)]
     return result
 
 

--- a/lingua_franca/lang/format_es.py
+++ b/lingua_franca/lang/format_es.py
@@ -195,11 +195,10 @@ def pronounce_number_es(num, places=2):
     # and dot, but when pronounced, its pronounced "coma"
     if not num == int(num) and places > 0:
         result += " coma"
-        place = 10
-        while int(num*place) % 10 > 0 and places > 0:
-            result += " " + NUM_STRING_ES[int(num*place) % 10]
-            place *= 10
-            places -= 1
+        _num_str = str(num)
+        _num_str = _num_str.split(".")[1][0:places]
+        for char in _num_str:
+            result += " " + NUM_STRING_ES[int(char)]
     return result
 
 

--- a/lingua_franca/lang/format_es.py
+++ b/lingua_franca/lang/format_es.py
@@ -194,6 +194,8 @@ def pronounce_number_es(num, places=2):
     # instead the dot. Decimal part can be written both with comma
     # and dot, but when pronounced, its pronounced "coma"
     if not num == int(num) and places > 0:
+        if abs(num) < 1.0 and (result is "menos " or not result):
+            result += "cero"
         result += " coma"
         _num_str = str(num)
         _num_str = _num_str.split(".")[1][0:places]

--- a/lingua_franca/lang/format_fr.py
+++ b/lingua_franca/lang/format_fr.py
@@ -193,11 +193,10 @@ def pronounce_number_fr(num, places=2):
     # Deal with decimal part
     if not num == int(num) and places > 0:
         result += " virgule"
-        place = 10
-        while int(num*place) % 10 > 0 and places > 0:
-            result += " " + NUM_STRING_FR[int(num*place) % 10]
-            place *= 10
-            places -= 1
+        _num_str = str(num)
+        _num_str = _num_str.split(".")[1][0:places]
+        for char in _num_str:
+            result += " " + NUM_STRING_FR[int(char)]
     return result
 
 

--- a/lingua_franca/lang/format_fr.py
+++ b/lingua_franca/lang/format_fr.py
@@ -192,6 +192,8 @@ def pronounce_number_fr(num, places=2):
 
     # Deal with decimal part
     if not num == int(num) and places > 0:
+        if abs(num) < 1.0 and (result is "moins " or not result):
+            result += "zéro"
         result += " virgule"
         _num_str = str(num)
         _num_str = _num_str.split(".")[1][0:places]

--- a/lingua_franca/lang/format_it.py
+++ b/lingua_franca/lang/format_it.py
@@ -384,8 +384,8 @@ def pronounce_number_it(num, places=2, short_scale=False, scientific=False):
 
     # Deal with fractional part
     if not num == int(num) and places > 0:
-        if num < 1.0 and not result:
-            result = "zero"
+        if abs(num) < 1.0 and (result is "meno " or not result):
+            result += "zero"
         result += " virgola"
         _num_str = str(num)
         _num_str = _num_str.split(".")[1][0:places]

--- a/lingua_franca/lang/format_it.py
+++ b/lingua_franca/lang/format_it.py
@@ -384,12 +384,13 @@ def pronounce_number_it(num, places=2, short_scale=False, scientific=False):
 
     # Deal with fractional part
     if not num == int(num) and places > 0:
+        if num < 1.0 and not result:
+            result = "zero"
         result += " virgola"
-        place = 10
-        while int(num * place) % 10 > 0 and places > 0:
-            result += " " + number_names[int(num * place) % 10]
-            place *= 10
-            places -= 1
+        _num_str = str(num)
+        _num_str = _num_str.split(".")[1][0:places]
+        for char in _num_str:
+            result += " " + number_names[int(char)]
     return result
 
 

--- a/lingua_franca/lang/format_pt.py
+++ b/lingua_franca/lang/format_pt.py
@@ -105,6 +105,8 @@ def pronounce_number_pt(num, places=2):
     # instead the dot. Decimal part can be written both with comma
     # and dot, but when pronounced, its pronounced "virgula"
     if not num == int(num) and places > 0:
+        if abs(num) < 1.0 and (result is "menos " or not result):
+            result += "zero"
         result += " vírgula"
         _num_str = str(num)
         _num_str = _num_str.split(".")[1][0:places]

--- a/lingua_franca/lang/format_pt.py
+++ b/lingua_franca/lang/format_pt.py
@@ -106,11 +106,10 @@ def pronounce_number_pt(num, places=2):
     # and dot, but when pronounced, its pronounced "virgula"
     if not num == int(num) and places > 0:
         result += " vírgula"
-        place = 10
-        while int(num * place) % 10 > 0 and places > 0:
-            result += " " + _NUM_STRING_PT[int(num * place) % 10]
-            place *= 10
-            places -= 1
+        _num_str = str(num)
+        _num_str = _num_str.split(".")[1][0:places]
+        for char in _num_str:
+            result += " " + _NUM_STRING_PT[int(char)]
     return result
 
 

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -118,6 +118,7 @@ class TestPronounceNumber(unittest.TestCase):
         self.assertEqual(pronounce_number(-33), "minus thirty three")
 
     def test_convert_decimals(self):
+        self.assertEqual(pronounce_number(0.05), "zero point zero five")
         self.assertEqual(pronounce_number(1.234),
                          "one point two three")
         self.assertEqual(pronounce_number(21.234),

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -119,6 +119,7 @@ class TestPronounceNumber(unittest.TestCase):
 
     def test_convert_decimals(self):
         self.assertEqual(pronounce_number(0.05), "zero point zero five")
+        self.assertEqual(pronounce_number(-0.05), "minus zero point zero five")
         self.assertEqual(pronounce_number(1.234),
                          "one point two three")
         self.assertEqual(pronounce_number(21.234),

--- a/test/test_format_es.py
+++ b/test/test_format_es.py
@@ -132,6 +132,8 @@ class TestPronounceNumber(unittest.TestCase):
                          "menos noventa y nueve")
 
     def test_convert_decimals(self):
+        self.assertEqual(pronounce_number(
+            0.05, lang="es"), "cero coma cero cinco")
         self.assertEqual(pronounce_number(1.234, lang="es"),
                          "uno coma dos tres")
         self.assertEqual(pronounce_number(21.234, lang="es"),

--- a/test/test_format_es.py
+++ b/test/test_format_es.py
@@ -134,6 +134,8 @@ class TestPronounceNumber(unittest.TestCase):
     def test_convert_decimals(self):
         self.assertEqual(pronounce_number(
             0.05, lang="es"), "cero coma cero cinco")
+        self.assertEqual(pronounce_number(
+            -0.05, lang="es"), "menos cero coma cero cinco")
         self.assertEqual(pronounce_number(1.234, lang="es"),
                          "uno coma dos tres")
         self.assertEqual(pronounce_number(21.234, lang="es"),

--- a/test/test_format_fr.py
+++ b/test/test_format_fr.py
@@ -137,6 +137,8 @@ class TestPronounceNumber_fr(unittest.TestCase):
     def test_convert_decimals_fr(self):
         self.assertEqual(pronounce_number(0.05, lang="fr-fr"),
                          "zéro virgule zéro cinq")
+        self.assertEqual(pronounce_number(-0.05, lang="fr-fr"),
+                         "moins zéro virgule zéro cinq")
         self.assertEqual(pronounce_number(1.234, lang="fr-fr"),
                          "un virgule deux trois")
         self.assertEqual(pronounce_number(21.234, lang="fr-fr"),

--- a/test/test_format_fr.py
+++ b/test/test_format_fr.py
@@ -135,6 +135,8 @@ class TestPronounceNumber_fr(unittest.TestCase):
                          "moins trente-trois")
 
     def test_convert_decimals_fr(self):
+        self.assertEqual(pronounce_number(0.05, lang="fr-fr"),
+                         "zéro virgule zéro cinq")
         self.assertEqual(pronounce_number(1.234, lang="fr-fr"),
                          "un virgule deux trois")
         self.assertEqual(pronounce_number(21.234, lang="fr-fr"),

--- a/test/test_format_it.py
+++ b/test/test_format_it.py
@@ -105,6 +105,8 @@ class TestPronounceNumber(unittest.TestCase):
         self.assertEqual(pronounce_number(-83, lang="it"), "meno ottantatre")
 
     def test_convert_decimals(self):
+        self.assertEqual(pronounce_number(
+            0.05, lang="it"), "zero virgola zero cinque")
         self.assertEqual(pronounce_number(1.234, lang="it"),
                          "uno virgola due tre")
         self.assertEqual(pronounce_number(21.234, lang="it"),
@@ -351,6 +353,7 @@ class TestPronounceNumber(unittest.TestCase):
                                           lang="it"), "infinito")
         self.assertEqual(pronounce_number(float("-inf"),
                                           lang="it"), "meno infinito")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_format_it.py
+++ b/test/test_format_it.py
@@ -107,6 +107,8 @@ class TestPronounceNumber(unittest.TestCase):
     def test_convert_decimals(self):
         self.assertEqual(pronounce_number(
             0.05, lang="it"), "zero virgola zero cinque")
+        self.assertEqual(pronounce_number(
+            -0.05, lang="it"), "meno zero virgola zero cinque")
         self.assertEqual(pronounce_number(1.234, lang="it"),
                          "uno virgola due tre")
         self.assertEqual(pronounce_number(21.234, lang="it"),

--- a/test/test_format_pt.py
+++ b/test/test_format_pt.py
@@ -89,6 +89,8 @@ class TestPronounceNumber(unittest.TestCase):
     def test_convert_decimals(self):
         self.assertEqual(pronounce_number(
             0.05, lang="pt"), "zero vírgula zero cinco")
+        self.assertEqual(pronounce_number(
+            -0.05, lang="pt"), "menos zero vírgula zero cinco")
         self.assertEqual(pronounce_number(1.234, lang="pt"),
                          "um vírgula dois três")
         self.assertEqual(pronounce_number(21.234, lang="pt"),

--- a/test/test_format_pt.py
+++ b/test/test_format_pt.py
@@ -87,6 +87,8 @@ class TestPronounceNumber(unittest.TestCase):
                          "menos noventa e nove")
 
     def test_convert_decimals(self):
+        self.assertEqual(pronounce_number(
+            0.05, lang="pt"), "zero vírgula zero cinco")
         self.assertEqual(pronounce_number(1.234, lang="pt"),
                          "um vírgula dois três")
         self.assertEqual(pronounce_number(21.234, lang="pt"),


### PR DESCRIPTION
Alter format.pronounce_number_en() to parse the decimal part using strings and characters rather than math.

Bug was due to int comparisons clobbering small numbers.

Closes #75 