### PR TITLE
fix #80 - capital letters break extract_number

### DIFF
--- a/lingua_franca/lang/parse_da.py
+++ b/lingua_franca/lang/parse_da.py
@@ -75,6 +75,8 @@ da_numbers = {
 # TODO: short_scale and ordinals don't do anything here.
 # The parameters are present in the function signature for API compatibility
 # reasons.
+
+
 def extractnumber_da(text, short_scale=True, ordinals=False):
     """
     This function prepares the given text for parsing by making
@@ -89,6 +91,7 @@ def extractnumber_da(text, short_scale=True, ordinals=False):
     'ein Pferd' means 'one horse' and 'a horse'
 
     """
+    text = text.lower()
     aWords = text.split()
     aWords = [word for word in aWords if
               word not in ["den", "det"]]
@@ -182,13 +185,13 @@ def extract_datetime_da(string, currentDate, default_time):
 
     def date_found():
         return found or \
-               (
-                       datestr != "" or timeStr != "" or
-                       yearOffset != 0 or monthOffset != 0 or
-                       dayOffset is True or hrOffset != 0 or
-                       hrAbs or minOffset != 0 or
-                       minAbs or secOffset != 0
-               )
+            (
+                datestr != "" or timeStr != "" or
+                yearOffset != 0 or monthOffset != 0 or
+                dayOffset is True or hrOffset != 0 or
+                hrAbs or minOffset != 0 or
+                minAbs or secOffset != 0
+            )
 
     if string == "" or not currentDate:
         return None

--- a/lingua_franca/lang/parse_de.py
+++ b/lingua_franca/lang/parse_de.py
@@ -80,6 +80,8 @@ de_numbers = {
 # TODO: short_scale and ordinals don't do anything here.
 # The parameters are present in the function signature for API compatibility
 # reasons.
+
+
 def extractnumber_de(text, short_scale=True, ordinals=False):
     """
     This function prepares the given text for parsing by making
@@ -94,6 +96,7 @@ def extractnumber_de(text, short_scale=True, ordinals=False):
     'ein Pferd' means 'one horse' and 'a horse'
 
     """
+    text = text.lower()
     aWords = text.split()
     aWords = [word for word in aWords if
               word not in ["der", "die", "das", "des", "den", "dem"]]
@@ -187,13 +190,13 @@ def extract_datetime_de(string, currentDate, default_time):
 
     def date_found():
         return found or \
-               (
-                       datestr != "" or timeStr != "" or
-                       yearOffset != 0 or monthOffset != 0 or
-                       dayOffset is True or hrOffset != 0 or
-                       hrAbs or minOffset != 0 or
-                       minAbs or secOffset != 0
-               )
+            (
+                datestr != "" or timeStr != "" or
+                yearOffset != 0 or monthOffset != 0 or
+                dayOffset is True or hrOffset != 0 or
+                hrAbs or minOffset != 0 or
+                minAbs or secOffset != 0
+            )
 
     if string == "" or not currentDate:
         return None

--- a/lingua_franca/lang/parse_en.py
+++ b/lingua_franca/lang/parse_en.py
@@ -54,10 +54,10 @@ _SUMS = {'twenty', '20', 'thirty', '30', 'forty', '40', 'fifty', '50',
          'sixty', '60', 'seventy', '70', 'eighty', '80', 'ninety', '90'}
 
 _MULTIPLIES_LONG_SCALE_EN = set(_LONG_SCALE_EN.values()) | \
-                            generate_plurals_en(_LONG_SCALE_EN.values())
+    generate_plurals_en(_LONG_SCALE_EN.values())
 
 _MULTIPLIES_SHORT_SCALE_EN = set(_SHORT_SCALE_EN.values()) | \
-                             generate_plurals_en(_SHORT_SCALE_EN.values())
+    generate_plurals_en(_SHORT_SCALE_EN.values())
 
 # split sentence parse separately and sum ( 2 and a half = 2 + 0.5 )
 _FRACTION_MARKER = {"and"}
@@ -249,7 +249,7 @@ def _extract_fraction_with_text_en(tokens, short_scale, ordinals):
             num2 = numbers2[0]
             if num1.value >= 1 and 0 < num2.value < 1:
                 return num1.value + num2.value, \
-                       num1.tokens + partitions[1] + num2.tokens
+                    num1.tokens + partitions[1] + num2.tokens
 
     return None, None
 
@@ -298,7 +298,7 @@ def _extract_decimal_with_text_en(tokens, short_scale, ordinals):
             # TODO handle number dot number number number
             if "." not in str(decimal.text):
                 return number.value + float('0.' + str(decimal.value)), \
-                       number.tokens + partitions[1] + decimal.tokens
+                    number.tokens + partitions[1] + decimal.tokens
     return None, None
 
 
@@ -507,7 +507,7 @@ def extractnumber_en(text, short_scale=True, ordinals=False):
                                    was found
 
     """
-    return _extract_number_with_text_en(tokenize(text),
+    return _extract_number_with_text_en(tokenize(text.lower()),
                                         short_scale, ordinals).value
 
 
@@ -623,13 +623,13 @@ def extract_datetime_en(string, dateNow, default_time):
 
     def date_found():
         return found or \
-               (
-                       datestr != "" or
-                       yearOffset != 0 or monthOffset != 0 or
-                       dayOffset is True or hrOffset != 0 or
-                       hrAbs or minOffset != 0 or
-                       minAbs or secOffset != 0
-               )
+            (
+                datestr != "" or
+                yearOffset != 0 or monthOffset != 0 or
+                dayOffset is True or hrOffset != 0 or
+                hrAbs or minOffset != 0 or
+                minAbs or secOffset != 0
+            )
 
     if string == "" or not dateNow:
         return None
@@ -942,7 +942,7 @@ def extract_datetime_en(string, dateNow, default_time):
         elif word == "tonight" or word == "night":
             if hrAbs is None:
                 hrAbs = 22
-            #used += 1 ## NOTE this breaks other tests, TODO refactor me!
+            # used += 1 ## NOTE this breaks other tests, TODO refactor me!
 
         # couple of time_unit
         elif word == "2" and wordNext == "of" and \
@@ -1129,8 +1129,8 @@ def extract_datetime_en(string, dateNow, default_time):
                     if (
                             int(strNum) > 100 and
                             (
-                                    wordPrev == "o" or
-                                    wordPrev == "oh"
+                                wordPrev == "o" or
+                                wordPrev == "oh"
                             )):
                         # 0800 hours (pronounced oh-eight-hundred)
                         strHH = str(int(strNum) // 100)
@@ -1143,8 +1143,8 @@ def extract_datetime_en(string, dateNow, default_time):
                              remainder == "hours" or remainder == "hour") and
                             word[0] != '0' and
                             (
-                                    int(strNum) < 100 or
-                                    int(strNum) > 2400
+                                int(strNum) < 100 or
+                                int(strNum) > 2400
                             )):
                         # ignores military time
                         # "in 3 hours"
@@ -1191,11 +1191,11 @@ def extract_datetime_en(string, dateNow, default_time):
                     elif (
                             wordNext == "" or wordNext == "o'clock" or
                             (
-                                    wordNext == "in" and
-                                    (
-                                            wordNextNext == "the" or
-                                            wordNextNext == timeQualifier
-                                    )
+                                wordNext == "in" and
+                                (
+                                        wordNextNext == "the" or
+                                        wordNextNext == timeQualifier
+                                )
                             ) or wordNext == 'tonight' or
                             wordNextNext == 'tonight'):
 

--- a/lingua_franca/lang/parse_es.py
+++ b/lingua_franca/lang/parse_es.py
@@ -72,7 +72,7 @@ def extractnumber_es(text, short_scale=True, ordinals=False):
         (int) or (float): The value of extracted number
 
     """
-    aWords = text.split()
+    aWords = text.lower().split()
     count = 0
     result = None
     while count < len(aWords):
@@ -355,13 +355,13 @@ def extract_datetime_es(input_str, currentDate=None, default_time=None):
 
     def date_found():
         return found or \
-               (
-                       datestr != "" or
-                       yearOffset != 0 or monthOffset != 0 or
-                       dayOffset is True or hrOffset != 0 or
-                       hrAbs or minOffset != 0 or
-                       minAbs or secOffset != 0
-               )
+            (
+                datestr != "" or
+                yearOffset != 0 or monthOffset != 0 or
+                dayOffset is True or hrOffset != 0 or
+                hrAbs or minOffset != 0 or
+                minAbs or secOffset != 0
+            )
 
     if input_str == "":
         return None
@@ -890,10 +890,10 @@ def extract_datetime_es(input_str, currentDate=None, default_time=None):
                         used = 1
                     elif (int(word) > 100 and
                           (
-                                  # wordPrev == "o" or
-                                  # wordPrev == "oh" or
-                                  wordPrev == "cero"
-                          )):
+                        # wordPrev == "o" or
+                        # wordPrev == "oh" or
+                        wordPrev == "cero"
+                    )):
                         # 0800 hours (pronounced oh-eight-hundred)
                         strHH = int(word) / 100
                         strMM = int(word) - strHH * 100
@@ -903,8 +903,8 @@ def extract_datetime_es(input_str, currentDate=None, default_time=None):
                             wordNext == "hora" and
                             word[0] != '0' and
                             (
-                                    int(word) < 100 and
-                                    int(word) > 2400
+                                int(word) < 100 and
+                                int(word) > 2400
                             )):
                         # ignores military time
                         # "in 3 hours"

--- a/lingua_franca/lang/parse_it.py
+++ b/lingua_franca/lang/parse_it.py
@@ -398,6 +398,7 @@ def extractnumber_it(text, short_scale=False, ordinals=False):
 
     """
 
+    text = text.lower()
     string_num_ordinal_it = {}
     # first, second...
     if ordinals:

--- a/lingua_franca/lang/parse_nl.py
+++ b/lingua_franca/lang/parse_nl.py
@@ -558,7 +558,7 @@ def extractnumber_nl(text, short_scale=True, ordinals=False):
         (int) or (float) or False: The extracted number or False if no number
                                    was found
     """
-    return _extract_number_with_text_nl(_tokenize(text),
+    return _extract_number_with_text_nl(_tokenize(text.lower()),
                                         short_scale, ordinals).value
 
 

--- a/lingua_franca/lang/parse_pt.py
+++ b/lingua_franca/lang/parse_pt.py
@@ -66,6 +66,8 @@ def isFractional_pt(input_str):
 # TODO: short_scale and ordinals don't do anything here.
 # The parameters are present in the function signature for API compatibility
 # reasons.
+
+
 def extractnumber_pt(text, short_scale=True, ordinals=False):
     """
     This function prepares the given text for parsing by making
@@ -76,6 +78,7 @@ def extractnumber_pt(text, short_scale=True, ordinals=False):
         (int) or (float): The value of extracted number
 
     """
+    text = text.lower()
     aWords = text.split()
     count = 0
     result = None
@@ -274,13 +277,13 @@ def extract_datetime_pt(input_str, currentDate, default_time):
 
     def date_found():
         return found or \
-               (
-                       datestr != "" or timeStr != "" or
-                       yearOffset != 0 or monthOffset != 0 or
-                       dayOffset is True or hrOffset != 0 or
-                       hrAbs or minOffset != 0 or
-                       minAbs or secOffset != 0
-               )
+            (
+                datestr != "" or timeStr != "" or
+                yearOffset != 0 or monthOffset != 0 or
+                dayOffset is True or hrOffset != 0 or
+                hrAbs or minOffset != 0 or
+                minAbs or secOffset != 0
+            )
 
     if input_str == "" or not currentDate:
         return None
@@ -817,10 +820,10 @@ def extract_datetime_pt(input_str, currentDate, default_time):
                         used = 1
                     elif (int(word) > 100 and
                           (
-                                  wordPrev == "o" or
-                                  wordPrev == "oh" or
-                                  wordPrev == "zero"
-                          )):
+                        wordPrev == "o" or
+                        wordPrev == "oh" or
+                        wordPrev == "zero"
+                    )):
                         # 0800 hours (pronounced oh-eight-hundred)
                         strHH = int(word) / 100
                         strMM = int(word) - strHH * 100
@@ -831,8 +834,8 @@ def extract_datetime_pt(input_str, currentDate, default_time):
                             wordNext == "hora" and
                             word[0] != '0' and
                             (
-                                    int(word) < 100 and
-                                    int(word) > 2400
+                                int(word) < 100 and
+                                int(word) > 2400
                             )):
                         # ignores military time
                         # "in 3 hours"

--- a/lingua_franca/lang/parse_sv.py
+++ b/lingua_franca/lang/parse_sv.py
@@ -20,6 +20,8 @@ from .parse_common import is_numeric, look_for_fractions
 # TODO: short_scale and ordinals don't do anything here.
 # The parameters are present in the function signature for API compatibility
 # reasons.
+
+
 def extractnumber_sv(text, short_scale=True, ordinals=False):
     """
     This function prepares the given text for parsing by making
@@ -29,6 +31,7 @@ def extractnumber_sv(text, short_scale=True, ordinals=False):
     Returns:
         (int) or (float): The value of extracted number
     """
+    text = text.lower()
     aWords = text.split()
     and_pass = False
     valPreAnd = False

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -88,6 +88,13 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(extract_number("three quarter cups"), 3.0 / 4.0)
         self.assertEqual(extract_number("three quarters cups"), 3.0 / 4.0)
         self.assertEqual(extract_number("twenty two"), 22)
+        self.assertEqual(extract_number(
+            "Twenty two with a leading capital letter"), 22)
+        self.assertEqual(extract_number(
+            "twenty Two with two capital letters"), 22)
+        self.assertEqual(extract_number(
+            "twenty Two with mixed capital letters"), 22)
+        self.assertEqual(extract_number("Twenty two and Three Fifths"), 22.6)
         self.assertEqual(extract_number("two hundred"), 200)
         self.assertEqual(extract_number("nine thousand"), 9000)
         self.assertEqual(extract_number("six hundred sixty six"), 666)
@@ -140,8 +147,10 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(extract_number("a couple hundred beers"), 200)
         self.assertEqual(extract_number("a couple thousand beers"), 2000)
 
-        self.assertEqual(extract_number("this is the 7th test", ordinals=True), 7)
-        self.assertEqual(extract_number("this is the 7th test", ordinals=False), 7)
+        self.assertEqual(extract_number(
+            "this is the 7th test", ordinals=True), 7)
+        self.assertEqual(extract_number(
+            "this is the 7th test", ordinals=False), 7)
         self.assertTrue(extract_number("this is the nth test") is False)
         self.assertEqual(extract_number("this is the 1st test"), 1)
         self.assertEqual(extract_number("this is the 2nd test"), 2)
@@ -151,8 +160,10 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(extract_number("this is the 33rd test"), 33)
         self.assertEqual(extract_number("this is the 34th test"), 34)
 
-        self.assertEqual(extract_number("you are the second one", ordinals=False), 1)
-        self.assertEqual(extract_number("you are the second one", ordinals=True), 2)
+        self.assertEqual(extract_number(
+            "you are the second one", ordinals=False), 1)
+        self.assertEqual(extract_number(
+            "you are the second one", ordinals=True), 2)
         self.assertEqual(extract_number("you are the 1st one"), 1)
         self.assertEqual(extract_number("you are the 2nd one"), 2)
         self.assertEqual(extract_number("you are the 3rd one"), 3)
@@ -534,7 +545,7 @@ class TestNormalize(unittest.TestCase):
                     "2017-06-28 00:00:00", "my birthday is")
         testExtract("my birthday is 2 days after yesterday",
                     "2017-06-28 00:00:00", "my birthday is")
-        
+
         #  "# days ago>"
         testExtract("my birthday was 1 day ago",
                     "2017-06-26 00:00:00", "my birthday was")

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -91,7 +91,7 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(extract_number(
             "Twenty two with a leading capital letter"), 22)
         self.assertEqual(extract_number(
-            "twenty Two with two capital letters"), 22)
+            "twenty Two with Two capital letters"), 22)
         self.assertEqual(extract_number(
             "twenty Two with mixed capital letters"), 22)
         self.assertEqual(extract_number("Twenty two and Three Fifths"), 22.6)

--- a/test/test_parse_da.py
+++ b/test/test_parse_da.py
@@ -35,12 +35,12 @@ class TestNormalize(unittest.TestCase):
 
     def test_extract_number(self):
         self.assertEqual(extract_number("dette er den første test",
-                         lang="da-dk"), 1)
+                                        lang="da-dk"), 1)
 #        self.assertEqual(extract_number("dette er den 1. test",
 #                                        lang="da-dk"),
 #                         1)
         self.assertEqual(extract_number("dette er den anden test",
-                         lang="da-dk"), 2)
+                                        lang="da-dk"), 2)
 #        self.assertEqual(extract_number("dette er den 2. test",
 #                                        lang="da-dk"),
 #                         2)
@@ -48,6 +48,8 @@ class TestNormalize(unittest.TestCase):
             extract_number("dette er den tredie test", lang="da-dk"), 3)
         self.assertEqual(
             extract_number("dette er test nummer fire", lang="da-dk"), 4)
+        self.assertEqual(
+            extract_number("dette er test nummer Fire", lang="da-dk"), 4)
         self.assertEqual(
             extract_number("en trediedel af en kop", lang="da-dk"), 1.0 / 3.0)
         self.assertEqual(extract_number("tre kopper", lang="da-dk"), 3)

--- a/test/test_parse_de.py
+++ b/test/test_parse_de.py
@@ -69,6 +69,8 @@ class TestNormalize(unittest.TestCase):
                          3.0 / 4.0)
         self.assertEqual(extract_number("drei Viertel Tassen", lang="de-de"),
                          3.0 / 4.0)
+        self.assertEqual(extract_number("Drei Viertel Tassen", lang="de-de"),
+                         3.0 / 4.0)
 
     def test_extractdatetime_de(self):
         def extractWithFormat(text):

--- a/test/test_parse_es.py
+++ b/test/test_parse_es.py
@@ -20,6 +20,7 @@ from lingua_franca.parse import (normalize, extract_numbers, extract_number,
                                  extract_datetime, extract_datetime_es,
                                  isFractional_es)
 
+
 class TestNormalize(unittest.TestCase):
     """
         Test cases for Spanish parsing
@@ -85,6 +86,7 @@ class TestNormalize(unittest.TestCase):
             "1 7 cuatro albuquerque naranja John Doe catorce ocho 157",
             lang='es')), [1, 4, 7, 8, 14, 157])
         self.assertEqual(extract_number("seis punto dos", lang='es'), 6.2)
+        self.assertEqual(extract_number("seis punto Dos", lang='es'), 6.2)
         self.assertEqual(extract_number("seis coma dos", lang='es'), 6.2)
         self.assertEqual(extract_numbers("un medio", lang='es'), [0.5])
         self.assertEqual(extract_number("cuarto", lang='es'), 0.25)
@@ -105,7 +107,7 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(isFractional_es("centésima"), 1.0 / 100)
         self.assertEqual(isFractional_es("centésimo"), 1.0 / 100)
         self.assertEqual(isFractional_es("milésima"), 1.0 / 1000)
-    
+
     @unittest.skip("unwritten logic")
     def test_comma_fraction_logic_es(self):
         # Logic has not been written to parse "#,#" as "#.#"
@@ -119,7 +121,7 @@ class TestDatetime_es(unittest.TestCase):
         # test currentDate==None
         _now = datetime.now()
         relative_year = _now.year if (_now.month == 1 and _now.day < 11) else \
-                        (_now.year + 1)
+            (_now.year + 1)
         self.assertEqual(extract_datetime_es("11 ene")[0],
                          datetime(relative_year, 1, 11))
 

--- a/test/test_parse_it.py
+++ b/test/test_parse_it.py
@@ -26,6 +26,7 @@ class TestNormalize(unittest.TestCase):
     """
         Test cases for Italian parsing
     """
+
     def test_articles_it(self):
         """
         Test cases for Italian remove_articles
@@ -199,6 +200,8 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(extract_number('tre dozzine di uova',
                                         lang='it'), 36)
         self.assertEqual(extract_number('zero gatti',
+                                        lang='it'), 0)
+        self.assertEqual(extract_number('Zero gatti',
                                         lang='it'), 0)
 
     def test_extractdatetime_it_not_normalized(self):

--- a/test/test_parse_nl.py
+++ b/test/test_parse_nl.py
@@ -44,6 +44,8 @@ class TestParsing(unittest.TestCase):
         self.assertEqual(
             extract_number("dit is Test drie", lang=LANG), 3)
         self.assertEqual(
+            extract_number("dit is Test Drie", lang=LANG), 3)
+        self.assertEqual(
             extract_number("dit is de Test Nummer 4", lang=LANG), 4)
         self.assertEqual(extract_number("één derde kopje",
                                         lang=LANG), 1.0 / 3.0)

--- a/test/test_parse_pt.py
+++ b/test/test_parse_pt.py
@@ -30,7 +30,7 @@ class TestNormalize(unittest.TestCase):
     def test_articles_pt(self):
         self.assertEqual(normalize("isto é o teste",
                                    lang="pt", remove_articles=True),
-                                   "isto é teste")
+                         "isto é teste")
         self.assertEqual(
             normalize("isto é a frase", lang="pt", remove_articles=True),
             "isto é frase")
@@ -40,7 +40,6 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(normalize("isto é o teste extra",
                                    lang="pt",
                                    remove_articles=False), "isto é o teste extra")
-
 
     def test_extractnumber_pt(self):
         self.assertEqual(extract_number("isto e o primeiro teste", lang="pt"),
@@ -66,6 +65,9 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(extract_number("um cafe e um meio", lang="pt"), 1.5)
         self.assertEqual(
             extract_number("tres quartos de chocolate", lang="pt"),
+            3.0 / 4.0)
+        self.assertEqual(
+            extract_number("Tres quartos de chocolate", lang="pt"),
             3.0 / 4.0)
         self.assertEqual(extract_number("três quarto de chocolate",
                                         lang="pt"), 3.0 / 4.0)

--- a/test/test_parse_sv.py
+++ b/test/test_parse_sv.py
@@ -39,6 +39,8 @@ class TestNormalize(unittest.TestCase):
                                         lang='sv-se'), 1.0 / 3.0)
         self.assertEqual(extract_number("tre deciliter",
                                         lang='sv-se'), 3)
+        self.assertEqual(extract_number("Tre deciliter",
+                                        lang='sv-se'), 3)
         self.assertEqual(extract_number("1/3 deciliter",
                                         lang='sv-se'), 1.0 / 3.0)
         self.assertEqual(extract_number("en kvarts dl",


### PR DESCRIPTION
`extract_number()` helpers (`extractnumber_en()` and so forth):
  - convert input string to lowercase before parsing
  - bug not present in `extractnumber_fr()`

-----

Same/similar change to all but one parser. This could be handled as a
one-liner in the top-level functions, but somebody might import the
lang-specific helpers someday, and this bug would be a nasty surprise.

closes #80 