### PR TITLE
fix #81

### DIFF
--- a/lingua_franca/lang/parse_en.py
+++ b/lingua_franca/lang/parse_en.py
@@ -444,7 +444,11 @@ def _extract_whole_number_with_text_en(tokens, short_scale, ordinals):
                 current_val = val
 
         else:
-            if prev_word in _SUMS and word not in _SUMS and current_val >= 10:
+            if all([
+                prev_word in _SUMS,
+                word not in _SUMS,
+                word not in multiplies,
+                current_val >= 10]):
                 # Backtrack - we've got numbers we can't sum.
                 number_words.pop()
                 val = prev_val

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -123,6 +123,18 @@ class TestNormalize(unittest.TestCase):
                                         short_scale=False), 1e12)
         self.assertEqual(extract_number("this is the billionth test",
                                         short_scale=False), 1e-12)
+
+        # Verify non-power multiples of ten no longer discard
+        # adjacent multipliers
+        self.assertEqual(extract_number("twenty thousand"), 20000)
+        self.assertEqual(extract_number("fifty million"), 50000000)
+
+        # This test fails due to 
+        # self.assertEqual(extract_number("twenty billion three hundred million \
+        #                                 nine hundred fifty thousand six hundred \
+        #                                 seventy five point eight six"),
+        #                                 20300950675.86)
+
         # TODO handle this case
         # self.assertEqual(
         #    extract_number("6 dot six six six"),


### PR DESCRIPTION
Fix: multiples of ten which are not powers of ten will no longer fail
to multiply with members of `parse_en.multiplies`.

Closes #81 

I should point out that #86 is still breaking the same function, so this *probably* isn't the whole thing. But as soon as we've got a hotfix for that other one, I recommend publishing a minor version immediately.