### PR TITLE
fix #88 and #93: multiple decimal places and multiple decimal numbers

### DIFF
--- a/lingua_franca/lang/parse_en.py
+++ b/lingua_franca/lang/parse_en.py
@@ -337,19 +337,21 @@ def _extract_decimal_with_text_en(tokens, short_scale, ordinals, places=None):
                 return_value = float('0.' + "".join([str(
                     decimal.value) for decimal in numbers2]))
                 return_value = number.value + return_value
-                if places:
+                if places is not None:
                     if places == 0:
                         return_value = ceil(return_value)
                     elif places == -1:
                         return_value = floor(return_value)
-
+                    if places < 1:
+                        return_value = int(return_value)
                 return_tokens = number.tokens + partitions[1]
                 for n in numbers2:
                     return_tokens += n.tokens
                 if not places:
                     return return_value, return_tokens
 
-                return (round(return_value, places) if places else return_value), return_tokens
+                return (round(return_value, places) if places > 0
+                        else return_value), return_tokens
     return None, None
 
 

--- a/lingua_franca/lang/parse_en.py
+++ b/lingua_franca/lang/parse_en.py
@@ -289,7 +289,7 @@ def _extract_decimal_with_text_en(tokens, short_scale, ordinals, places=None):
     for c in _DECIMAL_MARKER:
         partitions = partition_list(tokens, lambda t: t.word == c)
 
-        if len(partitions) == 3:
+        if len(partitions) >= 3:
             numbers1 = \
                 _extract_numbers_with_text_en(partitions[0], short_scale,
                                               ordinals, fractional_numbers=False,
@@ -301,7 +301,6 @@ def _extract_decimal_with_text_en(tokens, short_scale, ordinals, places=None):
             if not numbers1 or not numbers2:
                 return None, None
 
-            token_idx = numbers2[0].tokens[0].index
             idx = 1
             stop = False
             while idx < len(numbers2) and not stop:
@@ -604,7 +603,7 @@ def extractnumber_en(text, short_scale=True, ordinals=False, decimal_places=None
         text (str): the string to normalize
         short_scale (bool): use short scale if True, long scale if False
         ordinals (bool): consider ordinal numbers, third=3 instead of 1/3
-        decimal_places (int or False): rounds to # decimal places. uses builtin round()
+        decimal_places (int or None): rounds to # decimal places. uses builtin round()
     Returns:
         (int) or (float) or False: The extracted number or False if no number
                                    was found

--- a/lingua_franca/parse.py
+++ b/lingua_franca/parse.py
@@ -82,7 +82,7 @@ def match_one(query, choices):
 
 
 def extract_numbers(text, short_scale=True, ordinals=False, lang=None,
-                    decimal_places=False):
+                    decimal_places=None):
     """
         Takes in a string and extracts a list of numbers.
 
@@ -94,8 +94,13 @@ def extract_numbers(text, short_scale=True, ordinals=False, lang=None,
             See https://en.wikipedia.org/wiki/Names_of_large_numbers
         ordinals (bool): consider ordinal numbers, e.g. third=3 instead of 1/3
         lang (str): the BCP-47 code for the language to use, None uses default
-        decimal_places (int or False): rounds to # decimal places. Not yet implemented
-            in all languages. False performs no rounding. Uses builtin round()
+        decimal_places (int or None): Positive value will round to X places.
+                                      Val of 0 will round up to nearest int,
+                                        equivalent to `math.ceil(result)`
+                                      Val of -1 will round down to nearest int,
+                                        equivalent to `math.floor(result)`
+                                      Val of None will perform no rounding,
+                                      potentially returning a very long string.
     Returns:
         list: list of extracted numbers as floats, or empty list if none found
     """

--- a/lingua_franca/parse.py
+++ b/lingua_franca/parse.py
@@ -119,7 +119,7 @@ def extract_numbers(text, short_scale=True, ordinals=False, lang=None,
 
 
 def extract_number(text, short_scale=True, ordinals=False, lang=None,
-                   decimal_places=False):
+                   decimal_places=None):
     """Takes in a string and extracts a number.
 
     Args:
@@ -130,8 +130,13 @@ def extract_number(text, short_scale=True, ordinals=False, lang=None,
             See https://en.wikipedia.org/wiki/Names_of_large_numbers
         ordinals (bool): consider ordinal numbers, e.g. third=3 instead of 1/3
         lang (str): the BCP-47 code for the language to use, None uses default
-        decimal_places (int or False): rounds to # decimal places. Not yet implemented
-            in all languages. False performs no rounding. Uses builtin round()
+        decimal_places (int or None): Positive value will round to X places.
+                                      Val of 0 will round up to nearest int,
+                                        equivalent to `math.ceil(result)`
+                                      Val of -1 will round down to nearest int,
+                                        equivalent to `math.floor(result)`
+                                      Val of None will perform no rounding,
+                                      potentially returning a very long string.
     Returns:
         (int, float or False): The number extracted or False if the input
                                text contains no numbers

--- a/lingua_franca/parse.py
+++ b/lingua_franca/parse.py
@@ -77,8 +77,12 @@ def match_one(query, choices):
     else:
         return best
 
+# TODO update these docstrings when decimal_places has been implemented
+#     in all parsers
 
-def extract_numbers(text, short_scale=True, ordinals=False, lang=None):
+
+def extract_numbers(text, short_scale=True, ordinals=False, lang=None,
+                    decimal_places=False):
     """
         Takes in a string and extracts a list of numbers.
 
@@ -90,12 +94,14 @@ def extract_numbers(text, short_scale=True, ordinals=False, lang=None):
             See https://en.wikipedia.org/wiki/Names_of_large_numbers
         ordinals (bool): consider ordinal numbers, e.g. third=3 instead of 1/3
         lang (str): the BCP-47 code for the language to use, None uses default
+        decimal_places (int or False): rounds to # decimal places. Not yet implemented
+            in all languages. False performs no rounding. Uses builtin round()
     Returns:
         list: list of extracted numbers as floats, or empty list if none found
     """
     lang_code = get_primary_lang_code(lang)
     if lang_code == "en":
-        return extract_numbers_en(text, short_scale, ordinals)
+        return extract_numbers_en(text, short_scale, ordinals, decimal_places)
     elif lang_code == "de":
         return extract_numbers_de(text, short_scale, ordinals)
     elif lang_code == "fr":
@@ -112,7 +118,8 @@ def extract_numbers(text, short_scale=True, ordinals=False, lang=None):
     return []
 
 
-def extract_number(text, short_scale=True, ordinals=False, lang=None):
+def extract_number(text, short_scale=True, ordinals=False, lang=None,
+                   decimal_places=False):
     """Takes in a string and extracts a number.
 
     Args:
@@ -123,6 +130,8 @@ def extract_number(text, short_scale=True, ordinals=False, lang=None):
             See https://en.wikipedia.org/wiki/Names_of_large_numbers
         ordinals (bool): consider ordinal numbers, e.g. third=3 instead of 1/3
         lang (str): the BCP-47 code for the language to use, None uses default
+        decimal_places (int or False): rounds to # decimal places. Not yet implemented
+            in all languages. False performs no rounding. Uses builtin round()
     Returns:
         (int, float or False): The number extracted or False if the input
                                text contains no numbers
@@ -130,7 +139,7 @@ def extract_number(text, short_scale=True, ordinals=False, lang=None):
     lang_code = get_primary_lang_code(lang)
     if lang_code == "en":
         return extractnumber_en(text, short_scale=short_scale,
-                                ordinals=ordinals)
+                                ordinals=ordinals, decimal_places=decimal_places)
     elif lang_code == "es":
         return extractnumber_es(text)
     elif lang_code == "pt":

--- a/lingua_franca/parse.py
+++ b/lingua_franca/parse.py
@@ -94,13 +94,12 @@ def extract_numbers(text, short_scale=True, ordinals=False, lang=None,
             See https://en.wikipedia.org/wiki/Names_of_large_numbers
         ordinals (bool): consider ordinal numbers, e.g. third=3 instead of 1/3
         lang (str): the BCP-47 code for the language to use, None uses default
-        decimal_places (int or None): Positive value will round to X places.
-                                      Val of 0 will round up to nearest int,
-                                        equivalent to `math.ceil(result)`
-                                      Val of -1 will round down to nearest int,
-                                        equivalent to `math.floor(result)`
-                                      Val of None will perform no rounding,
-                                      potentially returning a very long string.
+        decimal_places (int) or None: Number of decimal places to return.
+            None performs no rounding
+            0 truncates the decimal part
+                ("one point two six one" becomes 1)
+            1+ rounds to that many places
+                (decimal_places=1 turns "one point two six one" into 1.2)
     Returns:
         list: list of extracted numbers as floats, or empty list if none found
     """

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -744,6 +744,17 @@ class TestNormalize(unittest.TestCase):
                                          " bingo ten nancy forty six test"
                                          " with decimal rounding", decimal_places=2),
                          [round(6.579, 2), 10, 46])
+        # test integer rounding, multiple decimals in string
+        self.assertEqual(extract_numbers(
+            "five hundred seventy point seven two and thirty one point eight"),
+            [570.72, 31.8])
+        self.assertEqual(extract_numbers(
+            "five hundred seventy point seven two and thirty one point eight",
+            decimal_places=0), [571, 32])
+        self.assertEqual(extract_numbers(
+            "five hundred seventy point seven two and thirty one point eight",
+            decimal_places=-1), [570, 31])
+
 
     def test_contractions(self):
         self.assertEqual(normalize("ain't"), "is not")

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -151,10 +151,12 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(extract_number("eight hundred trillion two hundred \
                                         fifty seven"), 800000000000257.0)
 
-        # TODO handle this case
-        # self.assertEqual(
-        #    extract_number("6 dot six six six"),
-        #    6.666)
+        self.assertEqual(extract_number("6 dot six six six"), 6.666)
+        self.assertEqual(extract_number(
+            "6 dot six six six", decimal_places=2), round(6.666, 2))
+        self.assertEqual(extract_number(
+            "6 point seventy", decimal_places=2), 6.7)
+
         self.assertTrue(extract_number("The tennis player is fast") is False)
         self.assertTrue(extract_number("fraggle") is False)
 
@@ -735,6 +737,13 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(extract_numbers("this is a seven eight nine and a"
                                          " half test"),
                          [7.0, 8.0, 9.5])
+        self.assertEqual(extract_numbers("this is a six point five seven nine"
+                                         " bingo ten nancy forty six test"),
+                         [6.579, 10.0, 46.0])
+        self.assertEqual(extract_numbers("this is a six point five seven nine"
+                                         " bingo ten nancy forty six test"
+                                         " with decimal rounding", decimal_places=2),
+                         [round(6.579, 2), 10, 46])
 
     def test_contractions(self):
         self.assertEqual(normalize("ain't"), "is not")

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -750,10 +750,10 @@ class TestNormalize(unittest.TestCase):
             [570.72, 31.8])
         self.assertEqual(extract_numbers(
             "five hundred seventy point seven two and thirty one point eight",
-            decimal_places=0), [571, 32])
+            decimal_places=1), [570.7, 31.8])
         self.assertEqual(extract_numbers(
             "five hundred seventy point seven two and thirty one point eight",
-            decimal_places=-1), [570, 31])
+            decimal_places=0), [570, 31])
 
 
     def test_contractions(self):


### PR DESCRIPTION
 * extract_number(), extract_numbers(), and all
   helper functions gain a keyword parameter
   `decimal_places` (for helpers, just `places`)
   which does what it sounds like, using builtin
   round().

 * avoid capturing non-adjacent numbers as decimal
   places

 * avoid capturing already-used decimal places as
   separate numbers in extract_numbers()

 * add a few tests for the above

----

closes #88, #93 