### PR TITLE
Fix SyntaxWarning where 'is' is used rather than '=='

### DIFF
--- a/lingua_franca/lang/format_en.py
+++ b/lingua_franca/lang/format_en.py
@@ -290,7 +290,7 @@ def pronounce_number_en(num, places=2, short_scale=True, scientific=False,
         return pronounce_number_en(num, places, short_scale, scientific=True)
     # Deal with fractional part
     elif not num == int(num) and places > 0:
-        if abs(num) < 1.0 and (result is "minus " or not result):
+        if abs(num) < 1.0 and (result == "minus " or not result):
             result += "zero"
         result += " point"
         _num_str = str(num)

--- a/lingua_franca/lang/format_es.py
+++ b/lingua_franca/lang/format_es.py
@@ -194,7 +194,7 @@ def pronounce_number_es(num, places=2):
     # instead the dot. Decimal part can be written both with comma
     # and dot, but when pronounced, its pronounced "coma"
     if not num == int(num) and places > 0:
-        if abs(num) < 1.0 and (result is "menos " or not result):
+        if abs(num) < 1.0 and (result == "menos " or not result):
             result += "cero"
         result += " coma"
         _num_str = str(num)

--- a/lingua_franca/lang/format_fr.py
+++ b/lingua_franca/lang/format_fr.py
@@ -192,7 +192,7 @@ def pronounce_number_fr(num, places=2):
 
     # Deal with decimal part
     if not num == int(num) and places > 0:
-        if abs(num) < 1.0 and (result is "moins " or not result):
+        if abs(num) < 1.0 and (result == "moins " or not result):
             result += "zéro"
         result += " virgule"
         _num_str = str(num)

--- a/lingua_franca/lang/format_it.py
+++ b/lingua_franca/lang/format_it.py
@@ -384,7 +384,7 @@ def pronounce_number_it(num, places=2, short_scale=False, scientific=False):
 
     # Deal with fractional part
     if not num == int(num) and places > 0:
-        if abs(num) < 1.0 and (result is "meno " or not result):
+        if abs(num) < 1.0 and (result == "meno " or not result):
             result += "zero"
         result += " virgola"
         _num_str = str(num)

--- a/lingua_franca/lang/format_pt.py
+++ b/lingua_franca/lang/format_pt.py
@@ -105,7 +105,7 @@ def pronounce_number_pt(num, places=2):
     # instead the dot. Decimal part can be written both with comma
     # and dot, but when pronounced, its pronounced "virgula"
     if not num == int(num) and places > 0:
-        if abs(num) < 1.0 and (result is "menos " or not result):
+        if abs(num) < 1.0 and (result == "menos " or not result):
             result += "zero"
         result += " vírgula"
         _num_str = str(num)

--- a/lingua_franca/lang/parse_en.py
+++ b/lingua_franca/lang/parse_en.py
@@ -401,7 +401,7 @@ def _extract_whole_number_with_text_en(tokens, short_scale, ordinals):
 
         # is the prev word an ordinal number and current word is one?
         # second one, third one
-        if ordinals and prev_word in string_num_ordinal and val is 1:
+        if ordinals and prev_word in string_num_ordinal and val == 1:
             val = prev_val
 
         # is the prev word a number and should we sum it?


### PR DESCRIPTION
Without this MR at least Python 3.8 will complain:

```
/usr/lib/python3.8/site-packages/lingua_franca/lang/format_en.py:293: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if abs(num) < 1.0 and (result is "minus " or not result):
/usr/lib/python3.8/site-packages/lingua_franca/lang/format_pt.py:108: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if abs(num) < 1.0 and (result is "menos " or not result):
/usr/lib/python3.8/site-packages/lingua_franca/lang/format_it.py:387: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if abs(num) < 1.0 and (result is "meno " or not result):
/usr/lib/python3.8/site-packages/lingua_franca/lang/format_es.py:197: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if abs(num) < 1.0 and (result is "menos " or not result):
/usr/lib/python3.8/site-packages/lingua_franca/lang/format_fr.py:195: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if abs(num) < 1.0 and (result is "moins " or not result):
/usr/lib/python3.8/site-packages/lingua_franca/lang/parse_en.py:404: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if ordinals and prev_word in string_num_ordinal and val is 1:
```