### PR TITLE
Make sure extract_datetime() returns None for all languages

### DIFF
--- a/lingua_franca/lang/parse_da.py
+++ b/lingua_franca/lang/parse_da.py
@@ -733,7 +733,7 @@ def extract_datetime_da(string, currentDate, default_time):
             found = True
 
     # check that we found a date
-    if not date_found:
+    if not date_found():
         return None
 
     if dayOffset is False:

--- a/lingua_franca/lang/parse_de.py
+++ b/lingua_franca/lang/parse_de.py
@@ -745,7 +745,7 @@ def extract_datetime_de(string, currentDate, default_time):
             found = True
 
     # check that we found a date
-    if not date_found:
+    if not date_found():
         return None
 
     if dayOffset is False:

--- a/lingua_franca/lang/parse_es.py
+++ b/lingua_franca/lang/parse_es.py
@@ -993,7 +993,7 @@ def extract_datetime_es(input_str, currentDate=None, default_time=None):
             found = True
 
     # check that we found a date
-    if not date_found:
+    if not date_found():
         return None
 
     if dayOffset is False:

--- a/lingua_franca/lang/parse_nl.py
+++ b/lingua_franca/lang/parse_nl.py
@@ -1305,7 +1305,7 @@ def extract_datetime_nl(string, dateNow, default_time):
             idx += used - 1
             found = True
     # check that we found a date
-    if not date_found:
+    if not date_found():
         return None
 
     if dayOffset is False:

--- a/lingua_franca/lang/parse_sv.py
+++ b/lingua_franca/lang/parse_sv.py
@@ -653,7 +653,7 @@ def extract_datetime_sv(string, currentDate, default_time):
             found = True
 
     # check that we found a date
-    if not date_found:
+    if not date_found():
         return None
 
     if dayOffset is False:

--- a/test/test_parse_da.py
+++ b/test/test_parse_da.py
@@ -158,6 +158,10 @@ class TestNormalize(unittest.TestCase):
 #        testExtract("lad os mødes klokken 8:00 om aftenen",
 #                    "2017-06-27 20:00:00", "lad os mødes")
 
+    def test_extractdatetime_no_time(self):
+        """Check that None is returned if no time is found in sentence."""
+        self.assertEqual(extract_datetime('ingen tid', lang='da-da'), None)
+
     def test_extractdatetime_default_da(self):
         default = time(9, 0, 0)
         anchor = datetime(2017, 6, 27, 0, 0)

--- a/test/test_parse_da.py
+++ b/test/test_parse_da.py
@@ -71,7 +71,7 @@ class TestNormalize(unittest.TestCase):
 #        self.assertEqual(extract_number("tre fjerdedel kop", lang="da-dk"),
 #                         3.0 / 4.0)
 
-    def test_extractdatetime_de(self):
+    def test_extractdatetime_da(self):
         def extractWithFormat(text):
             date = datetime(2017, 6, 27, 0, 0)
             [extractedDate, leftover] = extract_datetime(text, date,

--- a/test/test_parse_de.py
+++ b/test/test_parse_de.py
@@ -159,6 +159,10 @@ class TestNormalize(unittest.TestCase):
         testExtract("lass uns treffen um 8:00 abends",
                     "2017-06-27 20:00:00", "lass uns treffen")
 
+    def test_extractdatetime_no_time(self):
+        """Check that None is returned if no time is found in sentence."""
+        self.assertEqual(extract_datetime('kein zeit', lang='de-de'), None)
+
     def test_extractdatetime_default_de(self):
         default = time(9, 0, 0)
         anchor = datetime(2017, 6, 27, 0, 0)

--- a/test/test_parse_es.py
+++ b/test/test_parse_es.py
@@ -202,16 +202,16 @@ class TestDatetime_es(unittest.TestCase):
             "ayer por la tarde", anchorDate=datetime(1998, 1, 1),
             lang='es')[0], datetime(1997, 12, 31, 15))
 
-        self.assertEqual(extract_datetime(
-            "qué año es", anchorDate=datetime(1998, 1, 1),
-            lang='es')[0], datetime(1998, 1, 1))
-
         self.assertEqual(extract_datetime("hoy 2 de la mañana", lang='es',
                                           anchorDate=datetime(1998, 1, 1))[0],
                          datetime(1998, 1, 1, 2))
         self.assertEqual(extract_datetime("hoy 2 de la tarde", lang='es',
                                           anchorDate=datetime(1998, 1, 1))[0],
                          datetime(1998, 1, 1, 14))
+
+    def test_extractdatetime_no_time(self):
+        """Check that None is returned if no time is found in sentence."""
+        self.assertEqual(extract_datetime('no hay tiempo', lang='es-es'), None)
 
     @unittest.skip("These phrases are not parsing correctly.")
     def test_extract_datetime_relative_failing(self):

--- a/test/test_parse_nl.py
+++ b/test/test_parse_nl.py
@@ -146,6 +146,10 @@ class TestParsing(unittest.TestCase):
                                anchor, lang=LANG, default_time=default)
         self.assertEqual(default, res[0].time())
 
+    def test_extractdatetime_no_time(self):
+        """Check that None is returned if no time is found in sentence."""
+        self.assertEqual(extract_datetime('geen tijd', lang=LANG), None)
+
     def test_spaces(self):
         self.assertEqual(normalize("  dit   is  een    test", LANG),
                          "dit is 1 test")

--- a/test/test_parse_sv.py
+++ b/test/test_parse_sv.py
@@ -97,6 +97,10 @@ class TestNormalize(unittest.TestCase):
                                anchor, lang='sv-se', default_time=default)
         self.assertEqual(default, res[0].time())
 
+    def test_extractdatetime_no_time(self):
+        """Check that None is returned if no time is found in sentence."""
+        self.assertEqual(extract_datetime('Ingen tid', lang='sv-se'), None)
+
     def test_numbers(self):
         self.assertEqual(normalize("det här är ett ett två tre  test",
                                    lang='sv-se'),


### PR DESCRIPTION
The use of `date_found()` was corrected in some languages. This adds the `()` in a bunch of places and adds basic unittests for the return of `None`.

Should resolve #117