### PR TITLE
Small fix to enable german duration parsing

### DIFF
--- a/lingua_franca/lang/parse_de.py
+++ b/lingua_franca/lang/parse_de.py
@@ -121,7 +121,7 @@ def extract_duration_de(text):
     #### Einzahl und Mehrzahl
     pattern = r"(?P<value>\d+(?:\.?\d+)?)(?:\s+|\-){unit}[ne]?"
 
-    #### Einstiegspunkt für Text-zu-Zahlen Konversion
+    #### TODO Einstiegspunkt für Text-zu-Zahlen Konversion
     #text = _convert_words_to_numbers_de(text)
 
     for unit in time_units:

--- a/lingua_franca/parse.py
+++ b/lingua_franca/parse.py
@@ -26,6 +26,7 @@ from lingua_franca.lang.parse_sv import *
 from lingua_franca.lang.parse_de import extractnumber_de
 from lingua_franca.lang.parse_de import extract_numbers_de
 from lingua_franca.lang.parse_de import extract_datetime_de
+from lingua_franca.lang.parse_de import extract_duration_de
 from lingua_franca.lang.parse_de import normalize_de
 from lingua_franca.lang.parse_fr import extractnumber_fr
 from lingua_franca.lang.parse_fr import extract_numbers_fr
@@ -200,9 +201,11 @@ def extract_duration(text, lang=None):
         return extract_duration_en(text)
     if lang_code == "cs":
         return extract_duration_cs(text)
+    if lang_code == "de":
+        return extract_duration_cs(text)
 
     # TODO: extract_duration for other languages
-    _log_unsupported_language(lang_code, ['en','cs'])
+    _log_unsupported_language(lang_code, ['en','cs', 'de'])
     return None
 
 

--- a/lingua_franca/parse.py
+++ b/lingua_franca/parse.py
@@ -202,7 +202,7 @@ def extract_duration(text, lang=None):
     if lang_code == "cs":
         return extract_duration_cs(text)
     if lang_code == "de":
-        return extract_duration_cs(text)
+        return extract_duration_de(text)
 
     # TODO: extract_duration for other languages
     _log_unsupported_language(lang_code, ['en','cs', 'de'])

--- a/test/test_parse_de.py
+++ b/test/test_parse_de.py
@@ -166,6 +166,46 @@ class TestNormalize(unittest.TestCase):
                                anchor, lang='de-de', default_time=default)
         self.assertEqual(default, res[0].time())
 
+    def test_extract_duration_de(self):
+        self.assertEqual(extract_duration("10 sekunden"),
+                         (timedelta(seconds=10.0), ""))
+        self.assertEqual(extract_duration("5 minuten"),
+                         (timedelta(minutes=5), ""))
+        self.assertEqual(extract_duration("2 stunden"),
+                         (timedelta(hours=2), ""))
+        self.assertEqual(extract_duration("3 tage"),
+                         (timedelta(days=3), ""))
+        self.assertEqual(extract_duration("25 wochen"),
+                         (timedelta(weeks=25), ""))
+        # TODO no german text to number parsing yet
+        #self.assertEqual(extract_duration("sieben stunden"),
+        #                 (timedelta(hours=7), ""))
+        self.assertEqual(extract_duration("7.5 sekunden"),
+                         (timedelta(seconds=7.5), ""))
+        #self.assertEqual(extract_duration("eight and a half days thirty"
+        #                                  " nine seconds"),
+        #                 (timedelta(days=8.5, seconds=39), ""))
+        self.assertEqual(extract_duration("starte timer für 30 minuten"),
+                         (timedelta(minutes=30), "starte timer für"))
+        #self.assertEqual(extract_duration("Four and a half minutes until"
+        #                                  " sunset"),
+        #                 (timedelta(minutes=4.5), "until sunset"))
+        #self.assertEqual(extract_duration("Nineteen minutes past the hour"),
+        #                 (timedelta(minutes=19), "past the hour"))
+        self.assertEqual(extract_duration("weck mich in 3 wochen, "
+                                          " 497 tagen und"
+                                          " 391.6 sekunden"),
+                         (timedelta(weeks=3, days=497, seconds=391.6),
+                          "weck mich in , , und"))
+        #self.assertEqual(extract_duration("The movie is one hour, fifty seven"
+        #                                  " and a half minutes long"),
+        #                 (timedelta(hours=1, minutes=57.5),
+        #                     "the movie is ,  long"))
+        self.assertEqual(extract_duration("10-sekunden"),
+                         (timedelta(seconds=10.0), ""))
+        self.assertEqual(extract_duration("5-minuten"),
+                         (timedelta(minutes=5), ""))
+
     def test_spaces(self):
         self.assertEqual(normalize("  dies   ist  ein    test", lang="de-de"),
                          "dies ist 1 test")

--- a/test/test_parse_de.py
+++ b/test/test_parse_de.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 #
 import unittest
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 
 from lingua_franca.parse import extract_datetime
+from lingua_franca.parse import extract_duration
 from lingua_franca.parse import extract_number
 from lingua_franca.parse import normalize
 
@@ -167,25 +168,25 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(default, res[0].time())
 
     def test_extract_duration_de(self):
-        self.assertEqual(extract_duration("10 sekunden"),
+        self.assertEqual(extract_duration("10 sekunden", lang="de-de"),
                          (timedelta(seconds=10.0), ""))
-        self.assertEqual(extract_duration("5 minuten"),
+        self.assertEqual(extract_duration("5 minuten", lang="de-de"),
                          (timedelta(minutes=5), ""))
-        self.assertEqual(extract_duration("2 stunden"),
+        self.assertEqual(extract_duration("2 stunden", lang="de-de"),
                          (timedelta(hours=2), ""))
-        self.assertEqual(extract_duration("3 tage"),
+        self.assertEqual(extract_duration("3 tage", lang="de-de"),
                          (timedelta(days=3), ""))
-        self.assertEqual(extract_duration("25 wochen"),
+        self.assertEqual(extract_duration("25 wochen", lang="de-de"),
                          (timedelta(weeks=25), ""))
         # TODO no german text to number parsing yet
         #self.assertEqual(extract_duration("sieben stunden"),
         #                 (timedelta(hours=7), ""))
-        self.assertEqual(extract_duration("7.5 sekunden"),
+        self.assertEqual(extract_duration("7.5 sekunden", lang="de-de"),
                          (timedelta(seconds=7.5), ""))
         #self.assertEqual(extract_duration("eight and a half days thirty"
         #                                  " nine seconds"),
         #                 (timedelta(days=8.5, seconds=39), ""))
-        self.assertEqual(extract_duration("starte timer für 30 minuten"),
+        self.assertEqual(extract_duration("starte timer für 30 minuten", lang="de-de"),
                          (timedelta(minutes=30), "starte timer für"))
         #self.assertEqual(extract_duration("Four and a half minutes until"
         #                                  " sunset"),
@@ -193,17 +194,17 @@ class TestNormalize(unittest.TestCase):
         #self.assertEqual(extract_duration("Nineteen minutes past the hour"),
         #                 (timedelta(minutes=19), "past the hour"))
         self.assertEqual(extract_duration("weck mich in 3 wochen, "
-                                          " 497 tagen und"
-                                          " 391.6 sekunden"),
+                                          " 497 tage und"
+                                          " 391.6 sekunden", lang="de-de"),
                          (timedelta(weeks=3, days=497, seconds=391.6),
-                          "weck mich in , , und"))
+                          "weck mich in ,   und"))
         #self.assertEqual(extract_duration("The movie is one hour, fifty seven"
         #                                  " and a half minutes long"),
         #                 (timedelta(hours=1, minutes=57.5),
         #                     "the movie is ,  long"))
-        self.assertEqual(extract_duration("10-sekunden"),
+        self.assertEqual(extract_duration("10-sekunden", lang="de-de"),
                          (timedelta(seconds=10.0), ""))
-        self.assertEqual(extract_duration("5-minuten"),
+        self.assertEqual(extract_duration("5-minuten", lang="de-de"),
                          (timedelta(minutes=5), ""))
 
     def test_spaces(self):


### PR DESCRIPTION
In the current implementation it is not possible (for german clients) to parse german duration phrases without running into exceptions like gras64 described [here](https://github.com/MycroftAI/mycroft-timer/issues/70)

I added the specific lines to parse_de.py and rewrote the regex pattern and the time_units / {unit} handling, which could be adopted across the language spectrum.

In order to take affect **additional edits** in [mycroft-core/mycroft/util/parse.py](https://github.com/MycroftAI/mycroft-core/blob/d6cbccc0cbfbf6b540830aab4c15a32adf67b9bf/mycroft/util/parse.py#L222) have to be made, like 
```
     if lang_code == "de":
        return extract_duration_de(text)
_log_unsupported_language(lang_code, ['en, de'])
```

With the [PR on skill-timer](https://github.com/MycroftAI/mycroft-timer/pull/77) there should (hopefully) be a smooth experience so far as german clients are concerned. 