### PR TITLE
Fix another SyntaxWarning where 'is' is used rather than '=='

### DIFF
--- a/lingua_franca/lang/format_cs.py
+++ b/lingua_franca/lang/format_cs.py
@@ -293,7 +293,7 @@ def pronounce_number_cs(num, places=2, short_scale=True, scientific=False,
         return pronounce_number_cs(num, places, short_scale, scientific=True)
     # Deal with fractional part
     elif not num == int(num) and places > 0:
-        if abs(num) < 1.0 and (result is "mínus " or not result):
+        if abs(num) < 1.0 and (result == "mínus " or not result):
             result += "nula"
         result += " tečka"
         _num_str = str(num)


### PR DESCRIPTION
Seems another one slipped in somewhere in the last release.

Without this MR at least Python 3.8 will complain:

```
/usr/lib/python3.8/site-packages/lingua_franca/lang/format_cs.py:296: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if abs(num) < 1.0 and (result is "mínus " or not result):
```

Continuation of #112 I guess.