### PR TITLE
test_format_cs: remove testing for other languages

### DIFF
--- a/test/test_format_cs.py
+++ b/test/test_format_cs.py
@@ -497,22 +497,22 @@ class TestNiceDateFormat(unittest.TestCase):
                          "třičtvrtě na dva")
 
     def test_nice_date(self):
-        for lang in self.test_config:
-            i = 1
-            while (self.test_config[lang].get('test_nice_date') and
-                   self.test_config[lang]['test_nice_date'].get(str(i).encode('utf8'))):
-                p = self.test_config[lang]['test_nice_date'][str(i)]
-                dp = ast.literal_eval(p['datetime_param'])
-                np = ast.literal_eval(p['now'])
-                dt = datetime.datetime(
-                    dp[0], dp[1], dp[2], dp[3], dp[4], dp[5])
-                now = None if not np else datetime.datetime(
-                    np[0], np[1], np[2], np[3], np[4], np[5])
-                print('Testing for ' + lang + ' that ' + str(dt) +
-                      ' is date ' + p['assertEqual'])
-                self.assertEqual(p['assertEqual'],
-                                 nice_date(dt, lang=lang, now=now))
-                i = i + 1
+        lang = "cs-cz"
+        i = 1
+        while (self.test_config[lang].get('test_nice_date') and
+            self.test_config[lang]['test_nice_date'].get(str(i).encode('utf8'))):
+            p = self.test_config[lang]['test_nice_date'][str(i)]
+            dp = ast.literal_eval(p['datetime_param'])
+            np = ast.literal_eval(p['now'])
+            dt = datetime.datetime(
+                dp[0], dp[1], dp[2], dp[3], dp[4], dp[5])
+            now = None if not np else datetime.datetime(
+                np[0], np[1], np[2], np[3], np[4], np[5])
+            print('Testing for ' + lang + ' that ' + str(dt) +
+                    ' is date ' + p['assertEqual'])
+            self.assertEqual(p['assertEqual'],
+                                nice_date(dt, lang=lang, now=now))
+            i = i + 1
 
         # test fall back to english !!!Skiped
         #dt = datetime.datetime(2018, 2, 4, 0, 2, 3)
@@ -528,50 +528,49 @@ class TestNiceDateFormat(unittest.TestCase):
             self.assertTrue(len(nice_date(dt, lang=lang)) > 0)
 
     def test_nice_date_time(self):
-        for lang in self.test_config:
-            i = 1
-            while (self.test_config[lang].get('test_nice_date_time') and
-                   self.test_config[lang]['test_nice_date_time'].get(str(i).encode('utf8'))):
-                p = self.test_config[lang]['test_nice_date_time'][str(i)]
-                dp = ast.literal_eval(p['datetime_param'])
-                np = ast.literal_eval(p['now'])
-                dt = datetime.datetime(
-                    dp[0], dp[1], dp[2], dp[3], dp[4], dp[5])
-                now = None if not np else datetime.datetime(
-                    np[0], np[1], np[2], np[3], np[4], np[5])
-                print('Testing for ' + lang + ' that ' + str(dt) +
-                      ' is date time ' + p['assertEqual'])
-                self.assertEqual(
-                    p['assertEqual'],
-                    nice_date_time(
-                        dt, lang=lang, now=now,
-                        use_24hour=ast.literal_eval(p['use_24hour']),
-                        use_ampm=ast.literal_eval(p['use_ampm'])))
-                i = i + 1
+        lang = "cs-cz"
+        i = 1
+        while (self.test_config[lang].get('test_nice_date_time') and
+                self.test_config[lang]['test_nice_date_time'].get(str(i).encode('utf8'))):
+            p = self.test_config[lang]['test_nice_date_time'][str(i)]
+            dp = ast.literal_eval(p['datetime_param'])
+            np = ast.literal_eval(p['now'])
+            dt = datetime.datetime(
+                dp[0], dp[1], dp[2], dp[3], dp[4], dp[5])
+            now = None if not np else datetime.datetime(
+                np[0], np[1], np[2], np[3], np[4], np[5])
+            print('Testing for ' + lang + ' that ' + str(dt) +
+                    ' is date time ' + p['assertEqual'])
+            self.assertEqual(
+                p['assertEqual'],
+                nice_date_time(
+                    dt, lang=lang, now=now,
+                    use_24hour=ast.literal_eval(p['use_24hour']),
+                    use_ampm=ast.literal_eval(p['use_ampm'])))
+            i = i + 1
 
     def test_nice_year(self):
-        for lang in self.test_config:
-            i = 1
-            while (self.test_config[lang].get('test_nice_year') and
-                   self.test_config[lang]['test_nice_year'].get(str(i).encode('utf8'))):
-                p = self.test_config[lang]['test_nice_year'][str(i)]
-                dp = ast.literal_eval(p['datetime_param'])
-                dt = datetime.datetime(
-                    dp[0], dp[1], dp[2], dp[3], dp[4], dp[5])
-                print('Testing for ' + lang + ' that ' + str(dt) +
-                      ' is year ' + p['assertEqual'])
-                self.assertEqual(p['assertEqual'], nice_year(
-                    dt, lang=lang, bc=ast.literal_eval(p['bc'])))
-                i = i + 1
+        lang = "cs-cz"
+        i = 1
+        while (self.test_config[lang].get('test_nice_year') and
+                self.test_config[lang]['test_nice_year'].get(str(i).encode('utf8'))):
+            p = self.test_config[lang]['test_nice_year'][str(i)]
+            dp = ast.literal_eval(p['datetime_param'])
+            dt = datetime.datetime(
+                dp[0], dp[1], dp[2], dp[3], dp[4], dp[5])
+            print('Testing for ' + lang + ' that ' + str(dt) +
+                    ' is year ' + p['assertEqual'])
+            self.assertEqual(p['assertEqual'], nice_year(
+                dt, lang=lang, bc=ast.literal_eval(p['bc'])))
+            i = i + 1
 
         # Test all years from 0 to 9999 for all languages,
         # that some output is produced
-        for lang in self.test_config:
-            print("Test all years in " + lang)
-            for i in range(1, 9999):
-                dt = datetime.datetime(i, 1, 31, 13, 2, 3)
-                self.assertTrue(len(nice_year(dt, lang=lang)) > 0)
-                # Looking through the date sequence can be helpful
+        print("Test all years in " + lang)
+        for i in range(1, 9999):
+            dt = datetime.datetime(i, 1, 31, 13, 2, 3)
+            self.assertTrue(len(nice_year(dt, lang=lang)) > 0)
+            # Looking through the date sequence can be helpful
 
 #                print(nice_year(dt, lang=lang))
     def test_nice_duration(self):


### PR DESCRIPTION
Address issue #139
Removed for lops
Run tests only for "cs-cz"
All test passed