### PR TITLE
explicitly add files to source dist package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
 include readme.md
 include requirements.txt 
+recursive-include lingua_franca/res *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE
+include readme.md
+include requirements.txt 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("readme.md", "r") as fh:
 
 setup(
     name='lingua_franca',
-    version='0.3.0',
+    version='0.3.1',
     packages=['test', 'lingua_franca', 'lingua_franca.lang'],
     url='https://github.com/MycroftAI/lingua-franca',
     license='Apache2.0',


### PR DESCRIPTION
Key files are not being included in the source distribution. This adds a `MANIFEST.in` to explicitly include them.

We hit the same issue with the Messagebus Client recently and installations will fail without them present.