### PR TITLE
Fix/deprwarn bugs

### DIFF
--- a/lingua_franca/format.py
+++ b/lingua_franca/format.py
@@ -41,7 +41,7 @@ _REGISTERED_FUNCTIONS = ("nice_number",
 populate_localized_function_dict("format", langs=get_active_langs())
 
 
-def _translate_word(name, lang=None):
+def _translate_word(name, lang=''):
     """ Helper to get word translations
 
     Args:
@@ -53,6 +53,8 @@ def _translate_word(name, lang=None):
     """
     from lingua_franca.internal import resolve_resource_file
     if not lang:
+        if lang == None:
+            warn(NoneLangWarning)
         lang = get_default_loc()
 
     lang_code = lang if is_supported_full_lang(lang) else \
@@ -241,7 +243,7 @@ date_time_format = DateTimeFormat(os.path.join(os.path.dirname(__file__),
 
 
 @localized_function(run_own_code_on=[UnsupportedLanguageError])
-def nice_number(number, lang=None, speech=True, denominators=None):
+def nice_number(number, lang='', speech=True, denominators=None):
     """Format a float to human readable functions
 
     This function formats a float to human understandable functions. Like
@@ -258,7 +260,7 @@ def nice_number(number, lang=None, speech=True, denominators=None):
 
 
 @localized_function()
-def nice_time(dt, lang=None, speech=True, use_24hour=False,
+def nice_time(dt, lang='', speech=True, use_24hour=False,
               use_ampm=False):
     """
     Format a time to a comfortable human format
@@ -278,7 +280,7 @@ def nice_time(dt, lang=None, speech=True, use_24hour=False,
 
 
 @localized_function()
-def pronounce_number(number, lang=None, places=2, short_scale=True,
+def pronounce_number(number, lang='', places=2, short_scale=True,
                      scientific=False, ordinals=False):
     """
     Convert a number to it's spoken equivalent
@@ -296,7 +298,7 @@ def pronounce_number(number, lang=None, places=2, short_scale=True,
     """
 
 
-def nice_date(dt, lang=None, now=None):
+def nice_date(dt, lang='', now=None):
     """
     Format a datetime to a pronounceable date
 
@@ -318,7 +320,7 @@ def nice_date(dt, lang=None, now=None):
     return date_time_format.date_format(dt, full_code, now)
 
 
-def nice_date_time(dt, lang=None, now=None, use_24hour=False,
+def nice_date_time(dt, lang='', now=None, use_24hour=False,
                    use_ampm=False):
     """
         Format a datetime to a pronounceable date and time
@@ -347,7 +349,7 @@ def nice_date_time(dt, lang=None, now=None, use_24hour=False,
                                              use_ampm)
 
 
-def nice_year(dt, lang=None, bc=False):
+def nice_year(dt, lang='', bc=False):
     """
         Format a datetime to a pronounceable year
 
@@ -370,7 +372,7 @@ def nice_year(dt, lang=None, bc=False):
 
 
 @localized_function(run_own_code_on=[FunctionNotLocalizedError])
-def nice_duration(duration, lang=None, speech=True):
+def nice_duration(duration, lang='', speech=True):
     """ Convert duration in seconds to a nice spoken timespan
 
     Examples:
@@ -385,7 +387,8 @@ def nice_duration(duration, lang=None, speech=True):
         str: timespan as a string
     """
     if not lang:
-        warn(NoneLangWarning)
+        if lang == None:
+            warn(NoneLangWarning)
         lang = get_default_loc()
     if not is_supported_full_lang(lang):
         # TODO deprecated; delete when 'lang=None' and 'lang=invalid' are removed
@@ -458,7 +461,7 @@ def nice_duration(duration, lang=None, speech=True):
     return out
 
 
-def join_list(items, connector, sep=None, lang=None):
+def join_list(items, connector, sep=None, lang=''):
     """ Join a list into a phrase using the given connector word
 
     Examples:
@@ -521,7 +524,7 @@ def expand_options(parentheses_line: str) -> list:
 
 
 @localized_function()
-def nice_response(text, lang=None):
+def nice_response(text, lang=''):
     """
     In some languages, sanitizes certain numeric input for TTS
 

--- a/lingua_franca/format.py
+++ b/lingua_franca/format.py
@@ -53,7 +53,7 @@ def _translate_word(name, lang=''):
     """
     from lingua_franca.internal import resolve_resource_file
     if not lang:
-        if lang == None:
+        if lang is None:
             warn(NoneLangWarning)
         lang = get_default_loc()
 
@@ -387,7 +387,7 @@ def nice_duration(duration, lang='', speech=True):
         str: timespan as a string
     """
     if not lang:
-        if lang == None:
+        if lang is None:
             warn(NoneLangWarning)
         lang = get_default_loc()
     if not is_supported_full_lang(lang):

--- a/lingua_franca/internal.py
+++ b/lingua_franca/internal.py
@@ -37,9 +37,8 @@ _localized_functions = {}
 # commit 35efd0661a178e82f6745ad17e10e607c0d83472 for the "proper" state
 # of affairs, raising the errors below instead of deprecation warnings
 
-# For ease of development, in order to be able to type `if not lang:`
-# the default parameter to all functions should be changed back from
-# lang='' to lang=None when the deprecation is complete
+# Once the deprecation is complete, functions which have had their default
+# parameter changed from lang=None to lang='' should be switched back
 
 if version[:3] == '3.5':
     warn(DeprecationWarning("Python 3.5 is EOL, and no longer supported. "
@@ -300,7 +299,7 @@ def set_default_lang(lang_code):
 
 def get_primary_lang_code(lang=''):
     if not lang:
-        if lang == None:
+        if lang is None:
             warn(NoneLangWarning)
         lang = get_default_loc()
     # if not (lang):
@@ -353,7 +352,7 @@ def __get_primary_lang_code_deprecation_warning(lang=''):
 
 def get_full_lang_code(lang=''):
     if not lang:
-        if lang == None:
+        if lang is None:
             warn(NoneLangWarning)
         lang = get_default_loc()
     if not is_supported_full_lang(lang):
@@ -507,22 +506,17 @@ def localized_function(run_own_code_on=[type(None)]):
                     else:
                         warn(DeprecationWarning("The following warning will "
                                                 "become an exception in a future "
-                                                "version of Lingua Franca.".append(
-                                                    __error
-                                                )))
-                        # warn(__error)
+                                                "version of Lingua Franca." +
+                                                str(__error)))
                         lang_code = get_default_lang()
                         full_lang_code = get_full_lang_code()
                         __use_tmp = False
-                    # _raise_unsupported_language(lang_code)
                 if lang_code not in _SUPPORTED_LANGUAGES:
                     _raise_unsupported_language(lang_code)
                 if __use_tmp:
                     full_lang_code = tmp
             else:
-                full_lang_code = get_full_lang_code(lang_code)  # if \
-                # lang_code != get_default_lang() \
-                # else get_full_lang_code()
+                full_lang_code = get_full_lang_code(lang_code)
 
             # Here comes the ugly business.
             _module_name = func.__module__.split('.')[-1]

--- a/lingua_franca/internal.py
+++ b/lingua_franca/internal.py
@@ -37,6 +37,10 @@ _localized_functions = {}
 # commit 35efd0661a178e82f6745ad17e10e607c0d83472 for the "proper" state
 # of affairs, raising the errors below instead of deprecation warnings
 
+# For ease of development, in order to be able to type `if not lang:`
+# the default parameter to all functions should be changed back from
+# lang='' to lang=None when the deprecation is complete
+
 if version[:3] == '3.5':
     warn(DeprecationWarning("Python 3.5 is EOL, and no longer supported. "
                             "Lingua Franca supports it as a courtesy to "
@@ -294,9 +298,10 @@ def set_default_lang(lang_code):
 # TODO remove this when invalid lang codes are removed (currently deprecated)
 
 
-def get_primary_lang_code(lang=None):
+def get_primary_lang_code(lang=''):
     if not lang:
-        warn(NoneLangWarning)
+        if lang == None:
+            warn(NoneLangWarning)
         lang = get_default_loc()
     # if not (lang):
     try:
@@ -307,7 +312,7 @@ def get_primary_lang_code(lang=None):
     return lang
 
 
-def __get_primary_lang_code_deprecation_warning(lang=None):
+def __get_primary_lang_code_deprecation_warning(lang=''):
     """ Get the primary language code
 
     Args:
@@ -346,9 +351,10 @@ def __get_primary_lang_code_deprecation_warning(lang=None):
 # TODO remove this when invalid lang codes are removed (currently deprecated)
 
 
-def get_full_lang_code(lang=None):
+def get_full_lang_code(lang=''):
     if not lang:
-        warn(NoneLangWarning)
+        if lang == None:
+            warn(NoneLangWarning)
         lang = get_default_loc()
     if not is_supported_full_lang(lang):
         try:
@@ -359,7 +365,7 @@ def get_full_lang_code(lang=None):
     return lang
 
 
-def __get_full_lang_code_deprecation_warning(lang=None):
+def __get_full_lang_code_deprecation_warning(lang=''):
     """ Get the full language code
 
     Args:
@@ -408,7 +414,7 @@ def localized_function(run_own_code_on=[type(None)]):
     By contrast, here's the decorator above format.nice_number, with the param:
 
         @localized_function(run_own_code_on=[UnsupportedLanguageError])
-        def nice_number(number, lang=None, speech=True, denominators=None):
+        def nice_number(number, lang='', speech=True, denominators=None):
 
     Here, nice_number() itself will be executed in the event that the localizer
     raises an UnsupportedLanguageError.

--- a/lingua_franca/parse.py
+++ b/lingua_franca/parse.py
@@ -72,7 +72,7 @@ def match_one(query, choices):
 
 
 @localized_function()
-def extract_numbers(text, short_scale=True, ordinals=False, lang=None):
+def extract_numbers(text, short_scale=True, ordinals=False, lang=''):
     """
         Takes in a string and extracts a list of numbers.
 
@@ -90,7 +90,7 @@ def extract_numbers(text, short_scale=True, ordinals=False, lang=None):
 
 
 @localized_function()
-def extract_number(text, short_scale=True, ordinals=False, lang=None):
+def extract_number(text, short_scale=True, ordinals=False, lang=''):
     """Takes in a string and extracts a number.
 
     Args:
@@ -108,7 +108,7 @@ def extract_number(text, short_scale=True, ordinals=False, lang=None):
 
 
 @localized_function()
-def extract_duration(text, lang=None):
+def extract_duration(text, lang=''):
     """ Convert an english phrase into a number of seconds
 
     Convert things like:
@@ -137,7 +137,7 @@ def extract_duration(text, lang=None):
 
 
 @localized_function()
-def extract_datetime(text, anchorDate=None, lang=None, default_time=None):
+def extract_datetime(text, anchorDate=None, lang='', default_time=None):
     """
     Extracts date and time information from a sentence.  Parses many of the
     common ways that humans express dates and times, including relative dates
@@ -191,7 +191,7 @@ def extract_datetime(text, anchorDate=None, lang=None, default_time=None):
 
 
 @localized_function()
-def normalize(text, lang=None, remove_articles=True):
+def normalize(text, lang='', remove_articles=True):
     """Prepare a string for parsing
 
     This function prepares the given text for parsing by making
@@ -209,7 +209,7 @@ def normalize(text, lang=None, remove_articles=True):
 
 
 @localized_function()
-def get_gender(word, context="", lang=None):
+def get_gender(word, context="", lang=''):
     """ Guess the gender of a word
 
     Some languages assign genders to specific words.  This method will attempt
@@ -227,7 +227,7 @@ def get_gender(word, context="", lang=None):
 
 
 @localized_function()
-def is_fractional(input_str, short_scale=True, lang=None):
+def is_fractional(input_str, short_scale=True, lang=''):
     """
     This function takes the given text and checks if it is a fraction.
     Used by most of the number exractors.
@@ -245,7 +245,7 @@ def is_fractional(input_str, short_scale=True, lang=None):
 
 
 @localized_function()
-def is_ordinal(input_str, lang=None):
+def is_ordinal(input_str, lang=''):
     """
     This function takes the given text and checks if it is an ordinal number.
 


### PR DESCRIPTION
Several problems slipped through when 0.3.0 was altered to deprecate, rather than remove, `lang=None` and etc. as valid parameters.

The default value of the lang param, in several places, needs to change to an empty string, rather than None. This can be reverted once the deprecation is complete, and it probably should be, because future development will be much more pleasant when `if not lang` behaves consistently.

Also, I managed to leave a `str().append()` in there, I dunno how the suites missed that.