### PR TITLE
config.load_langs_on_demand: permits on-the-fly loading/unloading, to facilitate proc-gen use cases

### DIFF
--- a/lingua_franca/__init__.py
+++ b/lingua_franca/__init__.py
@@ -2,3 +2,5 @@ from .internal import get_default_lang, set_default_lang, get_default_loc, \
     get_active_langs, _set_active_langs, get_primary_lang_code, \
     get_full_lang_code, resolve_resource_file, load_language, \
     load_languages, unload_language, unload_languages, get_supported_langs
+
+from . import config

--- a/lingua_franca/__init__.py
+++ b/lingua_franca/__init__.py
@@ -3,4 +3,4 @@ from .internal import get_default_lang, set_default_lang, get_default_loc, \
     get_full_lang_code, resolve_resource_file, load_language, \
     load_languages, unload_language, unload_languages, get_supported_langs
 
-from . import config
+from lingua_franca import config

--- a/lingua_franca/config.py
+++ b/lingua_franca/config.py
@@ -1,0 +1,1 @@
+load_langs_on_demand = False

--- a/lingua_franca/internal.py
+++ b/lingua_franca/internal.py
@@ -5,7 +5,7 @@ from inspect import signature
 from sys import version
 from warnings import warn
 
-from . import config
+from lingua_franca import config
 
 _SUPPORTED_LANGUAGES = ("cs", "da", "de", "en", "es", "fr", "hu",
                         "it", "nl", "pl", "pt", "sv")

--- a/lingua_franca/internal.py
+++ b/lingua_franca/internal.py
@@ -459,8 +459,9 @@ def localized_function(run_own_code_on=[type(None)]):
     def localized_function_decorator(func):
         # Wrapper's logic
         def _call_localized_function(func, *args, **kwargs):
+            lang_code = None
             load_langs_on_demand = config.load_langs_on_demand
-            unload_language_afterward = True
+            unload_language_afterward = False
             func_signature = signature(func)
             func_params = list(func_signature.parameters)
             lang_param_index = func_params.index('lang')

--- a/test/test_localizer.py
+++ b/test/test_localizer.py
@@ -104,6 +104,16 @@ class TestDeprecation(unittest.TestCase):
 
 
 class TestLanguageLoading(unittest.TestCase):
+
+    def test_load_on_demand(self):
+        unload_all_languages()
+        lingua_franca.config.load_langs_on_demand = True
+        self.assertEqual(lingua_franca.parse.extract_number("one", lang="en"),
+                         1)
+        self.assertEqual(lingua_franca.parse.extract_number("uno", lang="es"),
+                         1)
+        lingua_franca.config.load_langs_on_demand = False
+
     def test_load_language(self):
         lingua_franca.load_language('en')
 

--- a/test/test_localizer.py
+++ b/test/test_localizer.py
@@ -107,12 +107,20 @@ class TestLanguageLoading(unittest.TestCase):
 
     def test_load_on_demand(self):
         unload_all_languages()
+        lingua_franca.load_language("en")
         lingua_franca.config.load_langs_on_demand = True
         self.assertEqual(lingua_franca.parse.extract_number("one", lang="en"),
                          1)
         self.assertEqual(lingua_franca.parse.extract_number("uno", lang="es"),
                          1)
+
         lingua_franca.config.load_langs_on_demand = False
+        # English should still be loaded, but not Spanish
+        self.assertEqual(lingua_franca.parse.extract_number("one", lang="en"),
+                         1)
+        with self.assertRaises(NoSuchModuleError):
+            lingua_franca.parse.extract_number("uno", lang="es")
+        unload_all_languages()
 
     def test_load_language(self):
         lingua_franca.load_language('en')


### PR DESCRIPTION
This branch (squash pls) adds `config.py` (eventually #128) with one variable: `load_langs_on_demand`.

When this variable is `True`, the localized function caller will - if and *only* if a language is passed which is not loaded - load the language, call the function, and unload the language.

At the moment, this is pretty fast, though it might need to be revisited if some languages become truly bloated with resource files.

This is only desirable in certain use cases, but, for instance, the absence of this flag was an obstacle for @JarbasAl's modular `text2speech` package, which doesn't always know the language it wants ahead of time.

I've tested this PR against that module, and it solves the problem. I want to stress that use cases like Mycroft, which prefer to utilize at most one engine per language, will *not* want to set this flag.