### PR TITLE
add file to credit "pre-spinoff" contributors

### DIFF
--- a/pre-spinoff-credits.md
+++ b/pre-spinoff-credits.md
@@ -1,0 +1,44 @@
+# List of Original Contributors
+
+Lingua Franca started as a spinoff from Mycroft-core (not a fork.) Consequently, the source repository no longer lists those who contributed to this code before the spinoff. Below is an attempt to list them.
+
+Some names may be missing. Some may be listed twice by mistake, especially if they've committed code under more than one name. Names are as they appeared in `git log`, or as they're familiar to the Mycroft community, and are in no particular order.
+
+If you notice a name is missing (especially your own!) please notify the LF maintainers. This list was created by naively parsing Mycroft-core's `git log`, and we may have missed a spot.
+
+---
+
+Ale  
+Andreas Lorensen  
+Angel Docampo  
+Augusto Monteiro  
+Cakeh  
+ChanceNCounter  
+Chris Rogers  
+Connor Penrod  
+Jarbas  
+Kévin C  
+Mike Woudenberg  
+ProsperousHeart  
+Silvia O'Dwyer  
+SoloVeniaASaludar  
+f-e-l-i-x  
+maxbachmann  
+penrods  
+Åke Forslund  
+Ashwin Venkatesan  
+Carsten Agerskov  
+G3RB3N  
+Matthew D. Scholefield  
+Michael Nguyen  
+c0r73x  
+danielwine  
+maxbachmann  
+Mike Woudenberg  
+Carsten Agerskov  
+Michalng  
+Thomas Doczkal  
+gras64  
+G3RB3N  
+danielwine  
+c0r73x  

--- a/pre-spinoff-credits.md
+++ b/pre-spinoff-credits.md
@@ -6,39 +6,49 @@ Some names may be missing. Some may be listed twice by mistake, especially if th
 
 If you notice a name is missing (especially your own!) please notify the LF maintainers. This list was created by naively parsing Mycroft-core's `git log`, and we may have missed a spot.
 
+Some notes from @penrods:
+
+> \<graybeard mode>
+>
+> For history's sake, here are a few tidbits:
+> 
+> * This grew from format.py and parse.py, originally in mycroft.util  
+>   * history of [parse.py](https://github.com/MycroftAI/mycroft-core/commits/release/v19.2.4?after=d0f55186cb4fbdf6b2fd18b218e004568124516f+34&branch=release%2Fv19.2.4&path%5B%5D=mycroft&path%5B%5D=util&path%5B%5D=parse.py)
+>   * history of [format.py](https://github.com/MycroftAI/mycroft-core/commits/release/v19.2.4?after=d0f55186cb4fbdf6b2fd18b218e004568124516f+34&branch=release%2Fv19.2.4&path%5B%5D=mycroft&path%5B%5D=util&path%5B%5D=format.py)  
+> * First real community contributions came during a sprint at PyCon 2017 in Portland. Several people (especially @ashwinjv and @ProsperousHeart) converted some PHP utilities for parsing/formatting I'd written as part of Christopher.  
+> * I'd always intended this to be generic, but I believe it was @JarbasAl who really lead the push to separate it to a fully independent library.
+>
+> \</graybeard mode>
+
+@ChanceNCounter's note: Penrod's right, it was Jarbas who got the fork off the ground. That's part of why he's credited with so many thousands of lines in this repo. The other reason is because he's written many thousands of lines in this repo.
+
 ---
 
+penrods  
+Jarbas  
 Ale  
+Åke Forslund  
 Andreas Lorensen  
 Angel Docampo  
+ashwinjv  
 Augusto Monteiro  
+Carsten Agerskov  
 Cakeh  
 ChanceNCounter  
 Chris Rogers  
 Connor Penrod  
-Jarbas  
+c0r73x  
+danielwine  
+f-e-l-i-x  
+gras64  
+G3RB3N  
 Kévin C  
+Matthew D. Scholefield  
+maxbachmann  
+Michalng  
+Michael Nguyen  
 Mike Woudenberg  
 ProsperousHeart  
 Silvia O'Dwyer  
 SoloVeniaASaludar  
-f-e-l-i-x  
-maxbachmann  
-penrods  
-Åke Forslund  
-Ashwin Venkatesan  
-Carsten Agerskov  
-G3RB3N  
-Matthew D. Scholefield  
-Michael Nguyen  
-c0r73x  
-danielwine  
-maxbachmann  
-Mike Woudenberg  
-Carsten Agerskov  
-Michalng  
 Thomas Doczkal  
-gras64  
-G3RB3N  
-danielwine  
-c0r73x  

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@ Lingua Franca (_noun_)<br>
     - [7. Commit changes](#7-commit-changes)
     - [8. Submit a PR](#8-submit-a-pr)
     - [9. Waiting for a review](#9-waiting-for-a-review)
+  - [Credits](#credits)
 
 ## Formatting
 
@@ -392,3 +393,15 @@ Like commit messages, the PR title and description should properly describe the 
 ### 10. Waiting for a review
 
 While you wait for a review of your contribution, why not take a moment to review some other pull requests? This is a great way to learn and help progress the queue of pull requests, which means your contribution will be seen more quickly!
+
+## Credits
+
+Though it is now a standalone package, Lingua Franca's codebase was a spinoff from Mycroft-core. In addition to those represented in Lingua Franca's git log, a great many people contributed to this code before the spinoff.  
+
+Although all are listed in MycroftAI's [List of Excellent People](https://github.com/MycroftAI/contributors), it seems proper to acknowledge the specific individuals who helped write *this* package, since they are no longer represented in `git log`.  
+
+To the best of the maintainers' knowledge, all of the "lost" contributors are listed in `pre-spinoff-credits.md`. Names are listed as they appeared in `git log`, or as they are known to the Mycroft community.  
+
+Those who've contributed since the spinoff are, of course, in Lingua Franca's `git log` and the GitHub "Contributors" pane. All contributors are on the List of Excellent People, regardless of when they contributed.  
+
+If you contributed to the original code, and your name is missing from `pre-spinoff-credits.md`, please inform a maintainer or file an issue, so we can give credit where credit is due!


### PR DESCRIPTION
Anybody who contributed to this codebase before it was spun off from Mycroft-core is (obviously) missing from `git log`.

I've attempted to list them.