### PR TITLE
drop support for python 3.5 (EOL)

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/lingua_franca/internal.py
+++ b/lingua_franca/internal.py
@@ -45,22 +45,8 @@ _localized_functions = {}
 # Once the deprecation is complete, functions which have had their default
 # parameter changed from lang=None to lang='' should be switched back
 
-if version[:3] == '3.5':
-    warn(DeprecationWarning("Python 3.5 is EOL, and no longer supported. "
-                            "Lingua Franca supports it as a courtesy to "
-                            "a downstream project, which will drop it soon. "
-                            "Expect LF to stop working in 3.5 any day now. "
-                            "There will be no announcement. This is your "
-                            "only warning. Migrate your projects."))
-
 
 class UnsupportedLanguageError(NotImplementedError):
-    pass
-
-# TODO this should descend from ModuleNotFoundError when we drop Py3.5
-
-
-class NoSuchModuleError(NotImplementedError):
     pass
 
 
@@ -494,10 +480,10 @@ def localized_function(run_own_code_on=[type(None)]):
             lang_code = lang_code or get_default_lang()
             if not lang_code:
                 if load_langs_on_demand:
-                    raise NoSuchModuleError("No language module loaded "
-                                            "and none specified.")
+                    raise ModuleNotFoundError("No language module loaded "
+                                              "and none specified.")
                 else:
-                    raise NoSuchModuleError("No language module loaded.")
+                    raise ModuleNotFoundError("No language module loaded.")
 
             if lang_code not in _SUPPORTED_LANGUAGES:
                 try:
@@ -537,17 +523,17 @@ def localized_function(run_own_code_on=[type(None)]):
             # The nonsense above gets you from lingua_franca.parse
             # to lingua_franca.lang.parse_xx
             if _module_name not in _localized_functions.keys():
-                raise NoSuchModuleError("Module lingua_franca." +
-                                        _module_name + " not recognized")
+                raise ModuleNotFoundError("Module lingua_franca." +
+                                          _module_name + " not recognized")
             if lang_code not in _localized_functions[_module_name].keys():
                 if load_langs_on_demand:
                     load_language(lang_code)
                     unload_language_afterward = True
                 else:
-                    raise NoSuchModuleError(_module_name +
-                                            " module of language '" +
-                                            lang_code +
-                                            "' is not currently loaded.")
+                    raise ModuleNotFoundError(_module_name +
+                                              " module of language '" +
+                                              lang_code +
+                                              "' is not currently loaded.")
             func_name = func.__name__.split('.')[-1]
             # At some point in the past, both the module and the language
             # were imported/loaded, respectively.
@@ -659,7 +645,7 @@ def populate_localized_function_dict(lf_module, langs=get_active_langs()):
         try:
             mod = import_module(".lang." + lf_module + "_" + primary_lang_code,
                                 "lingua_franca")
-        except NoSuchModuleError:
+        except ModuleNotFoundError:
             warn(Warning(bad_lang_code.format(primary_lang_code)))
             continue
 
@@ -773,4 +759,3 @@ def lookup_variant(mappings, key="variant"):
     except NotImplementedError as e:
         warn(str(e))
         return
-

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
         'Topic :: Text Processing :: Linguistic',
         'License :: OSI Approved :: Apache Software License',
 
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/test/test_localizer.py
+++ b/test/test_localizer.py
@@ -6,13 +6,7 @@ import lingua_franca
 import lingua_franca.parse
 import lingua_franca.format
 
-from lingua_franca.internal import localized_function, _SUPPORTED_LANGUAGES, \
-    NoSuchModuleError
-
-if version[:3] == '3.5':
-    raise unittest.SkipTest("Lingua Franca is dropping support for Python 3.5"
-                            " in the near future. These tests act weird in"
-                            " 3.5, but the contents are known to work.")
+from lingua_franca.internal import localized_function, _SUPPORTED_LANGUAGES
 
 
 def unload_all_languages():
@@ -20,7 +14,6 @@ def unload_all_languages():
         your test util to run them in order. Sadly, spamming this function
         is easier and probably less onerous for most devs.
     """
-    # lingua_franca.unload_languages(lingua_franca.get_active_langs())
     lingua_franca._set_active_langs([])
 
 
@@ -41,7 +34,7 @@ class TestException(unittest.TestCase):
 
     def test_must_load_language(self):
         unload_all_languages()
-        self.assertRaises(NoSuchModuleError,
+        self.assertRaises(ModuleNotFoundError,
                           lingua_franca.parse.extract_number, 'one')
 
     def test_run_own_code_on(self):
@@ -58,10 +51,10 @@ class TestException(unittest.TestCase):
         self.assertEqual(lingua_franca.format.nice_number(123.45, speech=False, lang='cz'),
                          "123.45")
         # It won't intercept other exceptions, though!
-        with self.assertRaises(NoSuchModuleError):
+        with self.assertRaises(ModuleNotFoundError):
             unload_all_languages()
             lingua_franca.format.nice_number(123.45)
-            # NoSuchModuleError: No language module loaded.
+            # ModuleNotFoundError: No language module loaded.
 
         with self.assertRaises(ValueError):
             @localized_function("not an error type")
@@ -118,7 +111,7 @@ class TestLanguageLoading(unittest.TestCase):
         # English should still be loaded, but not Spanish
         self.assertEqual(lingua_franca.parse.extract_number("one", lang="en"),
                          1)
-        with self.assertRaises(NoSuchModuleError):
+        with self.assertRaises(ModuleNotFoundError):
             lingua_franca.parse.extract_number("uno", lang="es")
         unload_all_languages()
 
@@ -135,7 +128,7 @@ class TestLanguageLoading(unittest.TestCase):
         self.assertFalse('es' in lingua_franca.get_active_langs())
 
         # Verify that unloaded languages can't be invoked explicitly
-        self.assertRaises(NoSuchModuleError,
+        self.assertRaises(ModuleNotFoundError,
                           lingua_franca.parse.extract_number,
                           'uno', lang='es')
         unload_all_languages()


### PR DESCRIPTION
We held out almost two whole months! 3.5 is donezo, though, and the supported versions contain some delicious syntactic sugar. To aid with the Catalan localization, a new wrapper has been introduced which takes advantage of that sugar. Furthermore, the 0.3 rebase *attempted* to utilize the newer `ModuleNotFoundError`, but 3.5 didn't have it.

Goodbye, 3.5!