### PR TITLE
Add extract_duration for french

### DIFF
--- a/lingua_franca/lang/parse_fr.py
+++ b/lingua_franca/lang/parse_fr.py
@@ -45,7 +45,7 @@ def extract_duration_fr(text):
     if not text:
         return None
 
-    text = text.lower()
+    text = normalize_fr(text)
 
     time_units = {
         'microseconds': 'microsecondes',
@@ -57,10 +57,7 @@ def extract_duration_fr(text):
         'weeks': 'semaines'
     }
 
-    pattern = r"(?P<value>\d+(?:\.?\d+)?)(?:\s+|\-){unit}[es]?"
-
-    # TODO words to number conversion
-    #text = _convert_words_to_numbers_fr(text)
+    pattern = r"(?P<value>\d+(?:\.?\d+)?)(?:\s+|\-){unit}[s]?(\s+|,|$)"
 
     for (unit_en, unit_fr) in time_units.items():
         unit_pattern = pattern.format(unit=unit_fr[:-1])  # remove 's' from unit

--- a/test/test_parse_fr.py
+++ b/test/test_parse_fr.py
@@ -342,27 +342,29 @@ class TestNormalize_fr(unittest.TestCase):
         self.assertEqual(extract_duration("25 semaines", lang="fr-fr"),
                          (timedelta(weeks=25), ""))
         # No conversion for work to number yet for fr
-        #self.assertEqual(extract_duration("sept heures"),
-        #                 (timedelta(hours=7), ""))
+        self.assertEqual(extract_duration("sept heures"),
+                         (timedelta(hours=7), ""))
         self.assertEqual(extract_duration("7.5 secondes", lang="fr-fr"),
                          (timedelta(seconds=7.5), ""))
-        #self.assertEqual(extract_duration("huit jours et demi et trente neuf secondes"),
-        #                 (timedelta(days=8.5, seconds=39), ""))
+        self.assertEqual(extract_duration("5 jours et vingt-neuf secondes"),
+                         (timedelta(days=5, seconds=29), "et"))
+        # Fraction not yet implemented
+        #self.assertEqual(extract_duration("huit jours et demi et trente-neuf secondes"),
+        #                 (timedelta(days=8.5, seconds=39), "et "))
         self.assertEqual(extract_duration("démarre un minuteur pour 30 minutes", lang="fr-fr"),
-                         (timedelta(minutes=30), "démarre un minuteur pour"))
+                         (timedelta(minutes=30), "démarre 1 minuteur pour"))
         #self.assertEqual(extract_duration("Quatre minutes et demi avant le coucher du soleil"),
         #                 (timedelta(minutes=4.5), "avant le coucher du soleil"))
-        #self.assertEqual(extract_duration("Une heure dix-neuf minutes"),
-        #                 (timedelta(hours=1, minutes=19), ""))
+        self.assertEqual(extract_duration("Une heure dix-neuf minutes"),
+                         (timedelta(hours=1, minutes=19), ""))
         self.assertEqual(extract_duration("réveille moi dans 3 semaines, "
                                           " 497 jours et"
                                           " 391.6 secondes", lang="fr-fr"),
                          (timedelta(weeks=3, days=497, seconds=391.6),
-                          "réveille moi dans ,   et"))
-        #self.assertEqual(extract_duration("Le film dure une heure, cinquante sept minutes"
-        #                                  " et demi"),
-        #                 (timedelta(hours=1, minutes=57.5),
-        #                     "le film dure ,"))
+                          "réveille moi dans  et"))
+        self.assertEqual(extract_duration("Le film dure une heure, cinquante-sept minutes"),
+                         (timedelta(hours=1, minutes=57),
+                             "film dure"))
         self.assertEqual(extract_duration("10-secondes", lang="fr-fr"),
                          (timedelta(seconds=10.0), ""))
         self.assertEqual(extract_duration("5-minutes", lang="fr-fr"),

--- a/test/test_parse_fr.py
+++ b/test/test_parse_fr.py
@@ -14,12 +14,13 @@
 # limitations under the License.
 #
 import unittest
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 
 from lingua_franca import load_language, unload_language, set_default_lang
 from lingua_franca.internal import FunctionNotLocalizedError
 from lingua_franca.parse import get_gender
 from lingua_franca.parse import extract_datetime
+from lingua_franca.parse import extract_duration
 from lingua_franca.parse import extract_number
 from lingua_franca.parse import normalize
 
@@ -328,6 +329,44 @@ class TestNormalize_fr(unittest.TestCase):
         res = extract_datetime("faire les plantations le 3ème jour de mars",
                                anchor, lang='fr-fr', default_time=default)
         self.assertEqual(default, res[0].time())
+
+    def test_extract_duration_fr(self):
+        self.assertEqual(extract_duration("10 secondes", lang="fr-fr"),
+                         (timedelta(seconds=10.0), ""))
+        self.assertEqual(extract_duration("5 minutes", lang="fr-fr"),
+                         (timedelta(minutes=5), ""))
+        self.assertEqual(extract_duration("2 heures", lang="fr-fr"),
+                         (timedelta(hours=2), ""))
+        self.assertEqual(extract_duration("3 jours", lang="fr-fr"),
+                         (timedelta(days=3), ""))
+        self.assertEqual(extract_duration("25 semaines", lang="fr-fr"),
+                         (timedelta(weeks=25), ""))
+        # No conversion for work to number yet for fr
+        #self.assertEqual(extract_duration("sept heures"),
+        #                 (timedelta(hours=7), ""))
+        self.assertEqual(extract_duration("7.5 secondes", lang="fr-fr"),
+                         (timedelta(seconds=7.5), ""))
+        #self.assertEqual(extract_duration("huit jours et demi et trente neuf secondes"),
+        #                 (timedelta(days=8.5, seconds=39), ""))
+        self.assertEqual(extract_duration("démarre un minuteur pour 30 minutes", lang="fr-fr"),
+                         (timedelta(minutes=30), "démarre un minuteur pour"))
+        #self.assertEqual(extract_duration("Quatre minutes et demi avant le coucher du soleil"),
+        #                 (timedelta(minutes=4.5), "avant le coucher du soleil"))
+        #self.assertEqual(extract_duration("Une heure dix-neuf minutes"),
+        #                 (timedelta(hours=1, minutes=19), ""))
+        self.assertEqual(extract_duration("réveille moi dans 3 semaines, "
+                                          " 497 jours et"
+                                          " 391.6 secondes", lang="fr-fr"),
+                         (timedelta(weeks=3, days=497, seconds=391.6),
+                          "réveille moi dans ,   et"))
+        #self.assertEqual(extract_duration("Le film dure une heure, cinquante sept minutes"
+        #                                  " et demi"),
+        #                 (timedelta(hours=1, minutes=57.5),
+        #                     "le film dure ,"))
+        self.assertEqual(extract_duration("10-secondes", lang="fr-fr"),
+                         (timedelta(seconds=10.0), ""))
+        self.assertEqual(extract_duration("5-minutes", lang="fr-fr"),
+                         (timedelta(minutes=5), ""))
 
     def test_spaces_fr(self):
         self.assertEqual(normalize("  c'est   le     test", lang="fr-fr"),


### PR DESCRIPTION
Add extract_duration support for french language (inspired from what was done for german).

#### Type of PR
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Unit tests added under ` test/test_parse_fr.py`  
