### PR TITLE
fix #178: don't install tests, just include

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE
 include readme.md
-include requirements.txt 
+include requirements.txt
+recursive-include test *.py
 recursive-include lingua_franca/res *

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("readme.md", "r") as fh:
 setup(
     name='lingua_franca',
     version='0.3.1',
-    packages=['test', 'lingua_franca', 'lingua_franca.lang'],
+    packages=['lingua_franca', 'lingua_franca.lang'],
     url='https://github.com/MycroftAI/lingua-franca',
     license='Apache2.0',
     package_data={'': extra_files},


### PR DESCRIPTION
I've removed the `tests` directory from `setup.py`, and included `test/ *.py` via `MANIFEST.in`, which is intended to ensure that tests are included with source distributions, but are not installed to the user's system.

I'm not 100% sure I've done this right, but when I make the sdist and unpack it, both `setup.py test` and `pytest test/` succeed as expected.

(see #178)

