### PR TITLE
feat/timezone_config

### DIFF
--- a/lingua_franca/config.py
+++ b/lingua_franca/config.py
@@ -1,2 +1,2 @@
 load_langs_on_demand = False
-inject_timezones = False
+inject_timezones = True

--- a/lingua_franca/config.py
+++ b/lingua_franca/config.py
@@ -1,1 +1,2 @@
 load_langs_on_demand = False
+inject_timezones = False

--- a/lingua_franca/internal.py
+++ b/lingua_franca/internal.py
@@ -459,12 +459,13 @@ def localized_function(run_own_code_on=[type(None)]):
             full_lang_code = None
 
             # Check if we need to add timezone awareness to any datetime object
-            for k, v in kwargs.items():
-                if isinstance(v, datetime):
-                    kwargs[k] = to_local(v)
-            for idx, v in enumerate(args):
-                if isinstance(v, datetime) and v.tzinfo is None:
-                    args = args[:idx] + (to_local(v),) + args[idx + 1:]
+            if config.inject_timezones:
+                for k, v in kwargs.items():
+                    if isinstance(v, datetime):
+                        kwargs[k] = to_local(v)
+                for idx, v in enumerate(args):
+                    if isinstance(v, datetime) and v.tzinfo is None:
+                        args = args[:idx] + (to_local(v),) + args[idx + 1:]
 
             # Check if we're passing a lang as a kwarg
             if 'lang' in kwargs.keys():

--- a/lingua_franca/internal.py
+++ b/lingua_franca/internal.py
@@ -460,12 +460,19 @@ def localized_function(run_own_code_on=[type(None)]):
 
             # Check if we need to add timezone awareness to any datetime object
             if config.inject_timezones:
-                for k, v in kwargs.items():
-                    if isinstance(v, datetime) and v.tzinfo is None:
-                        kwargs[k] = to_local(v)
-                for idx, v in enumerate(args):
-                    if isinstance(v, datetime) and v.tzinfo is None:
-                        args = args[:idx] + (to_local(v),) + args[idx + 1:]
+                for name_of_the_keyword_argument, \
+                    value_of_the_keyword_argument in kwargs.items():
+                    if isinstance(value_of_the_keyword_argument, datetime) \
+                            and value_of_the_keyword_argument.tzinfo is None:
+                        kwargs[name_of_the_keyword_argument] = to_local(
+                            value_of_the_keyword_argument)
+                for index_of_the_argument, value_of_the_argument in \
+                        enumerate(args):
+                    if isinstance(value_of_the_argument, datetime) \
+                            and value_of_the_argument.tzinfo is None:
+                        args = args[:index_of_the_argument] + \
+                               (to_local(value_of_the_argument),) + \
+                               args[index_of_the_argument + 1:]
 
             # Check if we're passing a lang as a kwarg
             if 'lang' in kwargs.keys():

--- a/lingua_franca/internal.py
+++ b/lingua_franca/internal.py
@@ -2,10 +2,12 @@ import os.path
 from functools import wraps
 from importlib import import_module
 from inspect import signature
-from sys import version
-from warnings import warn
 
+from warnings import warn
+from datetime import datetime
 from lingua_franca import config
+from lingua_franca.time import to_local
+
 
 _SUPPORTED_LANGUAGES = ("ca", "cs", "da", "de", "en", "es", "fr", "hu",
                         "it", "nl", "pl", "pt", "sl", "sv")
@@ -456,10 +458,18 @@ def localized_function(run_own_code_on=[type(None)]):
             lang_param_index = func_params.index('lang')
             full_lang_code = None
 
+            # Check if we need to add timezone awareness to any datetime object
+            for k, v in kwargs.items():
+                if isinstance(v, datetime):
+                    kwargs[k] = to_local(v)
+            for idx, v in enumerate(args):
+                if isinstance(v, datetime) and v.tzinfo is None:
+                    args = args[:idx] + (to_local(v),) + args[idx + 1:]
+
             # Check if we're passing a lang as a kwarg
             if 'lang' in kwargs.keys():
                 lang_param = kwargs['lang']
-                if lang_param == None:
+                if lang_param is None:
                     warn(NoneLangWarning)
                     lang_code = get_default_lang()
                 else:
@@ -468,7 +478,7 @@ def localized_function(run_own_code_on=[type(None)]):
             # Check if we're passing a lang as a positional arg
             elif lang_param_index < len(args):
                 lang_param = args[lang_param_index]
-                if lang_param == None:
+                if lang_param is None:
                     warn(NoneLangWarning)
                     lang_code = get_default_lang()
                 elif lang_param in _SUPPORTED_LANGUAGES or \

--- a/lingua_franca/internal.py
+++ b/lingua_franca/internal.py
@@ -461,7 +461,7 @@ def localized_function(run_own_code_on=[type(None)]):
             # Check if we need to add timezone awareness to any datetime object
             if config.inject_timezones:
                 for k, v in kwargs.items():
-                    if isinstance(v, datetime):
+                    if isinstance(v, datetime) and v.tzinfo is None:
                         kwargs[k] = to_local(v)
                 for idx, v in enumerate(args):
                     if isinstance(v, datetime) and v.tzinfo is None:

--- a/lingua_franca/lang/parse_ca.py
+++ b/lingua_franca/lang/parse_ca.py
@@ -22,6 +22,7 @@
 
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+from lingua_franca.time import now_local
 from lingua_franca.lang.parse_common import is_numeric, look_for_fractions
 from lingua_franca.lang.common_data_ca import _NUMBERS_CA, \
     _FEMALE_DETERMINANTS_CA, _FEMALE_ENDINGS_CA, \
@@ -337,9 +338,10 @@ def extract_datetime_ca(text, anchorDate=None, default_time=None):
                 minAbs or secOffset != 0
             )
 
-    if text == "" or not anchorDate:
+    if text == "":
         return None
 
+    anchorDate = anchorDate or now_local()
     found = False
     daySpecified = False
     dayOffset = False

--- a/lingua_franca/lang/parse_ca.py
+++ b/lingua_franca/lang/parse_ca.py
@@ -19,7 +19,7 @@
     TODO: numbers greater than 999999
     TODO: date time ca
 """
-
+from dateutil.tz import gettz
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from lingua_franca.time import now_local
@@ -997,6 +997,9 @@ def extract_datetime_ca(text, anchorDate=None, default_time=None):
             datestr = datestr.replace(monthsShort[idx], en_month)
 
         temp = datetime.strptime(datestr, "%B %d")
+        if extractedDate.tzinfo:
+            temp = temp.replace(tzinfo=gettz("UTC"))
+            temp = temp.astimezone(extractedDate.tzinfo)
         if not hasYear:
             temp = temp.replace(year=extractedDate.year)
             if extractedDate < temp:

--- a/lingua_franca/lang/parse_ca.py
+++ b/lingua_franca/lang/parse_ca.py
@@ -19,7 +19,6 @@
     TODO: numbers greater than 999999
     TODO: date time ca
 """
-from dateutil.tz import gettz
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from lingua_franca.time import now_local
@@ -998,8 +997,8 @@ def extract_datetime_ca(text, anchorDate=None, default_time=None):
 
         temp = datetime.strptime(datestr, "%B %d")
         if extractedDate.tzinfo:
-            temp = temp.replace(tzinfo=gettz("UTC"))
-            temp = temp.astimezone(extractedDate.tzinfo)
+            temp = temp.replace(tzinfo=extractedDate.tzinfo)
+
         if not hasYear:
             temp = temp.replace(year=extractedDate.year)
             if extractedDate < temp:

--- a/lingua_franca/lang/parse_cs.py
+++ b/lingua_franca/lang/parse_cs.py
@@ -760,9 +760,10 @@ def extract_datetime_cs(text, anchorDate=None, default_time=None):
                 minAbs or secOffset != 0
             )
 
-    if text == "" or not anchorDate:
+    if text == "":
         return None
 
+    anchorDate = anchorDate or now_local()
     found = False
     daySpecified = False
     dayOffset = False

--- a/lingua_franca/lang/parse_da.py
+++ b/lingua_franca/lang/parse_da.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from dateutil.tz import gettz
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from lingua_franca.lang.parse_common import is_numeric, look_for_fractions, \
@@ -709,6 +710,10 @@ def extract_datetime_da(text, anchorDate=None, default_time=None):
             datestr = datestr.replace(monthsShort[idx], en_month)
 
         temp = datetime.strptime(datestr, "%B %d")
+        if extractedDate.tzinfo:
+            temp = temp.replace(tzinfo=gettz("UTC"))
+            temp = temp.astimezone(extractedDate.tzinfo)
+
         if not hasYear:
             temp = temp.replace(year=extractedDate.year)
             if extractedDate < temp:

--- a/lingua_franca/lang/parse_da.py
+++ b/lingua_franca/lang/parse_da.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from dateutil.tz import gettz
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from lingua_franca.lang.parse_common import is_numeric, look_for_fractions, \
@@ -711,8 +710,7 @@ def extract_datetime_da(text, anchorDate=None, default_time=None):
 
         temp = datetime.strptime(datestr, "%B %d")
         if extractedDate.tzinfo:
-            temp = temp.replace(tzinfo=gettz("UTC"))
-            temp = temp.astimezone(extractedDate.tzinfo)
+            temp = temp.replace(tzinfo=extractedDate.tzinfo)
 
         if not hasYear:
             temp = temp.replace(year=extractedDate.year)

--- a/lingua_franca/lang/parse_da.py
+++ b/lingua_franca/lang/parse_da.py
@@ -19,6 +19,7 @@ from lingua_franca.lang.parse_common import is_numeric, look_for_fractions, \
     extract_numbers_generic, Normalizer
 from lingua_franca.lang.common_data_da import _DA_NUMBERS
 from lingua_franca.lang.format_da import pronounce_number_da
+from lingua_franca.time import now_local
 
 
 def extract_number_da(text, short_scale=True, ordinals=False):
@@ -141,9 +142,10 @@ def extract_datetime_da(text, anchorDate=None, default_time=None):
                 minAbs or secOffset != 0
             )
 
-    if text == "" or not anchorDate:
+    if text == "":
         return None
 
+    anchorDate = anchorDate or now_local()
     found = False
     daySpecified = False
     dayOffset = False

--- a/lingua_franca/lang/parse_de.py
+++ b/lingua_franca/lang/parse_de.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 import re
-from dateutil.tz import gettz
 from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 from lingua_franca.lang.parse_common import is_numeric, look_for_fractions, \
@@ -838,8 +837,7 @@ def extract_datetime_de(text, anchorDate=None, default_time=None):
 
         temp = datetime.strptime(datestr, "%B %d")
         if extractedDate.tzinfo:
-            temp = temp.replace(tzinfo=gettz("UTC"))
-            temp = temp.astimezone(extractedDate.tzinfo)
+            temp = temp.replace(tzinfo=extractedDate.tzinfo)
 
         if not hasYear:
             temp = temp.replace(year=extractedDate.year)

--- a/lingua_franca/lang/parse_de.py
+++ b/lingua_franca/lang/parse_de.py
@@ -20,6 +20,8 @@ from lingua_franca.lang.parse_common import is_numeric, look_for_fractions, \
     extract_numbers_generic, Normalizer
 from lingua_franca.lang.common_data_de import _DE_NUMBERS
 from lingua_franca.lang.format_de import pronounce_number_de
+from lingua_franca.time import now_local
+
 
 de_numbers = {
     'null': 0,
@@ -260,9 +262,10 @@ def extract_datetime_de(text, anchorDate=None, default_time=None):
                 minAbs or secOffset != 0
             )
 
-    if text == "" or not anchorDate:
+    if text == "":
         return None
 
+    anchorDate = anchorDate or now_local()
     found = False
     daySpecified = False
     dayOffset = False

--- a/lingua_franca/lang/parse_de.py
+++ b/lingua_franca/lang/parse_de.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import re
+from dateutil.tz import gettz
 from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 from lingua_franca.lang.parse_common import is_numeric, look_for_fractions, \
@@ -836,6 +837,10 @@ def extract_datetime_de(text, anchorDate=None, default_time=None):
             datestr = datestr.replace(monthsShort[idx], en_month)
 
         temp = datetime.strptime(datestr, "%B %d")
+        if extractedDate.tzinfo:
+            temp = temp.replace(tzinfo=gettz("UTC"))
+            temp = temp.astimezone(extractedDate.tzinfo)
+
         if not hasYear:
             temp = temp.replace(year=extractedDate.year)
             if extractedDate < temp:

--- a/lingua_franca/lang/parse_en.py
+++ b/lingua_franca/lang/parse_en.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta
 
 from dateutil.relativedelta import relativedelta
 
+from lingua_franca.time import now_local
 from lingua_franca.lang.parse_common import is_numeric, look_for_fractions, \
     invert_dict, ReplaceableNumber, partition_list, tokenize, Token, Normalizer
 from lingua_franca.lang.common_data_en import _ARTICLES_EN, _NUM_STRING_EN, \
@@ -671,8 +672,10 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
                 hrAbs or minOffset != 0 or
                 minAbs or secOffset != 0
             )
+
     if not anchorDate:
-        anchorDate = datetime.now()
+        anchorDate = now_local()
+
     if text == "":
         return None
 

--- a/lingua_franca/lang/parse_es.py
+++ b/lingua_franca/lang/parse_es.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 from datetime import datetime
-from dateutil.tz import gettz
 from dateutil.relativedelta import relativedelta
 
 from lingua_franca.time import now_local
@@ -1023,8 +1022,7 @@ def extract_datetime_es(text, anchorDate=None, default_time=None):
 
         temp = datetime.strptime(datestr, "%B %d")
         if extractedDate.tzinfo:
-            temp = temp.replace(tzinfo=gettz("UTC"))
-            temp = temp.astimezone(extractedDate.tzinfo)
+            temp = temp.replace(tzinfo=extractedDate.tzinfo)
         # temp = to_local(temp)
 
         if not hasYear:

--- a/lingua_franca/lang/parse_es.py
+++ b/lingua_franca/lang/parse_es.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from dateutil.tz import gettz
 from dateutil.relativedelta import relativedelta
 
-from lingua_franca.time import now_local, to_local
+from lingua_franca.time import now_local
 from lingua_franca.lang.format_es import pronounce_number_es
 from lingua_franca.lang.parse_common import *
 from lingua_franca.lang.common_data_es import _ARTICLES_ES, _STRING_NUM_ES

--- a/lingua_franca/lang/parse_es.py
+++ b/lingua_franca/lang/parse_es.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 from datetime import datetime
+from dateutil.tz import gettz
 from dateutil.relativedelta import relativedelta
 
 from lingua_franca.time import now_local, to_local
@@ -1021,18 +1022,19 @@ def extract_datetime_es(text, anchorDate=None, default_time=None):
             datestr = datestr.replace(monthsShort[idx], en_month)
 
         temp = datetime.strptime(datestr, "%B %d")
-        temp = to_local(temp)
+        if extractedDate.tzinfo:
+            temp = temp.replace(tzinfo=gettz("UTC"))
+            temp = temp.astimezone(extractedDate.tzinfo)
+        # temp = to_local(temp)
 
         if not hasYear:
             temp = temp.replace(year=extractedDate.year)
 
             if extractedDate < temp:
-                extractedDate = extractedDate.replace(year=int(currentYear),
-                                                      month=int(
-                                                          temp.strftime(
-                                                              "%m")),
-                                                      day=int(temp.strftime(
-                                                          "%d")))
+                extractedDate = extractedDate.replace(
+                    year=int(currentYear),
+                    month=int(temp.strftime("%m")),
+                    day=int(temp.strftime("%d")))
             else:
                 extractedDate = extractedDate.replace(
                     year=int(currentYear) + 1,

--- a/lingua_franca/lang/parse_es.py
+++ b/lingua_franca/lang/parse_es.py
@@ -15,7 +15,8 @@
 #
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
-from dateutil.tz import gettz
+
+from lingua_franca.time import now_local, to_local
 from lingua_franca.lang.format_es import pronounce_number_es
 from lingua_franca.lang.parse_common import *
 from lingua_franca.lang.common_data_es import _ARTICLES_ES, _STRING_NUM_ES
@@ -367,7 +368,7 @@ def extract_datetime_es(text, anchorDate=None, default_time=None):
     if text == "":
         return None
     if anchorDate is None:
-        anchorDate = datetime.now()
+        anchorDate = now_local()
 
     found = False
     daySpecified = False
@@ -1020,7 +1021,8 @@ def extract_datetime_es(text, anchorDate=None, default_time=None):
             datestr = datestr.replace(monthsShort[idx], en_month)
 
         temp = datetime.strptime(datestr, "%B %d")
-        temp = temp.replace(tzinfo=None)
+        temp = to_local(temp)
+
         if not hasYear:
             temp = temp.replace(year=extractedDate.year)
 

--- a/lingua_franca/lang/parse_fr.py
+++ b/lingua_franca/lang/parse_fr.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import re
+from dateutil.tz import gettz
 from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 from lingua_franca.lang.parse_common import is_numeric, look_for_fractions, \
@@ -942,6 +943,9 @@ def extract_datetime_fr(text, anchorDate=None, default_time=None):
     if datestr != "":
         if not hasYear:
             temp = datetime.strptime(datestr, "%B %d")
+            if extractedDate.tzinfo:
+                temp = temp.replace(tzinfo=gettz("UTC"))
+                temp = temp.astimezone(extractedDate.tzinfo)
             temp = temp.replace(year=extractedDate.year)
             if extractedDate < temp:
                 extractedDate = extractedDate.replace(year=int(currentYear),

--- a/lingua_franca/lang/parse_fr.py
+++ b/lingua_franca/lang/parse_fr.py
@@ -21,6 +21,8 @@ from lingua_franca.lang.parse_common import is_numeric, look_for_fractions, \
 from lingua_franca.lang.format_fr import pronounce_number_fr
 from lingua_franca.lang.common_data_fr import _ARTICLES_FR, _NUMBERS_FR, \
     _ORDINAL_ENDINGS_FR
+from lingua_franca.time import now_local
+
 
 def extract_duration_fr(text):
     """
@@ -491,9 +493,10 @@ def extract_datetime_fr(text, anchorDate=None, default_time=None):
                 hrOffset != 0 or minOffset != 0 or secOffset != 0
             )
 
-    if text == "" or not anchorDate:
+    if text == "":
         return None
 
+    anchorDate = anchorDate or now_local()
     found = False
     daySpecified = False
     dayOffset = False

--- a/lingua_franca/lang/parse_hu.py
+++ b/lingua_franca/lang/parse_hu.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from datetime import datetime, timedelta
+from lingua_franca.time import now_local
 from lingua_franca.lang.parse_common import Normalizer
 
 

--- a/lingua_franca/lang/parse_it.py
+++ b/lingua_franca/lang/parse_it.py
@@ -21,6 +21,7 @@
 import collections
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+from lingua_franca.time import now_local
 from lingua_franca.lang.parse_common import is_numeric, look_for_fractions, \
     extract_numbers_generic, Normalizer
 from lingua_franca.lang.format_it import _LONG_SCALE_IT, _SHORT_SCALE_IT, \
@@ -493,9 +494,9 @@ def extract_datetime_it(text, anchorDate=None, default_time=None):
                 month_offset != 0 or day_offset is True or hr_offset != 0 or
                 hr_abs or min_offset != 0 or min_abs or sec_offset != 0)
 
-    if text == '' or not anchorDate:
+    if text == '':
         return None
-
+    anchorDate = anchorDate or now_local()
     found = False
     day_specified = False
     day_offset = False

--- a/lingua_franca/lang/parse_nl.py
+++ b/lingua_franca/lang/parse_nl.py
@@ -24,6 +24,7 @@ from .common_data_nl import _SHORT_ORDINAL_STRING_NL, _ARTICLES_NL, \
     _LONG_SCALE_NL, _MULTIPLIES_LONG_SCALE_NL, _MULTIPLIES_SHORT_SCALE_NL,\
     _NEGATIVES_NL, _SHORT_SCALE_NL, _STRING_LONG_ORDINAL_NL, _STRING_NUM_NL, \
     _STRING_SHORT_ORDINAL_NL, _SUMS_NL
+from lingua_franca.time import now_local
 import re
 
 
@@ -560,9 +561,10 @@ def extract_datetime_nl(text, anchorDate=None, default_time=None):
                 minAbs or secOffset != 0
             )
 
-    if text == "" or not anchorDate:
+    if text == "":
         return None
 
+    anchorDate = anchorDate or now_local()
     found = False
     daySpecified = False
     dayOffset = False

--- a/lingua_franca/lang/parse_pl.py
+++ b/lingua_franca/lang/parse_pl.py
@@ -23,7 +23,7 @@ from lingua_franca.lang.common_data_pl import _NUM_STRING_PL, \
     _SHORT_SCALE_PL, _SHORT_ORDINAL_PL, _FRACTION_STRING_PL, _TIME_UNITS_CONVERSION, \
     _TIME_UNITS_NORMALIZATION, _MONTHS_TO_EN, _DAYS_TO_EN, _ORDINAL_BASE_PL, \
     _ALT_ORDINALS_PL
-
+from lingua_franca.time import now_local
 import re
 
 
@@ -710,9 +710,10 @@ def extract_datetime_pl(string, dateNow=None, default_time=None):
                 minAbs or secOffset != 0
             )
 
-    if string == "" or not dateNow:
+    if string == "":
         return None
 
+    dateNow = now_local()
     found = False
     daySpecified = False
     dayOffset = False

--- a/lingua_franca/lang/parse_pl.py
+++ b/lingua_franca/lang/parse_pl.py
@@ -713,7 +713,7 @@ def extract_datetime_pl(string, dateNow=None, default_time=None):
     if string == "":
         return None
 
-    dateNow = now_local()
+    dateNow = dateNow or now_local()
     found = False
     daySpecified = False
     dayOffset = False

--- a/lingua_franca/lang/parse_pt.py
+++ b/lingua_franca/lang/parse_pt.py
@@ -21,6 +21,7 @@
 """
 
 from datetime import datetime
+from dateutil.tz import gettz
 from dateutil.relativedelta import relativedelta
 from lingua_franca.lang.parse_common import is_numeric, look_for_fractions
 from lingua_franca.lang.common_data_pt import _NUMBERS_PT, \
@@ -955,6 +956,10 @@ def extract_datetime_pt(text, anchorDate=None, default_time=None):
             datestr = datestr.replace(monthsShort[idx], en_month)
 
         temp = datetime.strptime(datestr, "%B %d")
+        if extractedDate.tzinfo:
+            temp = temp.replace(tzinfo=gettz("UTC"))
+            temp = temp.astimezone(extractedDate.tzinfo)
+
         if not hasYear:
             temp = temp.replace(year=extractedDate.year)
             if extractedDate < temp:

--- a/lingua_franca/lang/parse_pt.py
+++ b/lingua_franca/lang/parse_pt.py
@@ -21,7 +21,6 @@
 """
 
 from datetime import datetime
-from dateutil.tz import gettz
 from dateutil.relativedelta import relativedelta
 from lingua_franca.lang.parse_common import is_numeric, look_for_fractions
 from lingua_franca.lang.common_data_pt import _NUMBERS_PT, \
@@ -957,8 +956,7 @@ def extract_datetime_pt(text, anchorDate=None, default_time=None):
 
         temp = datetime.strptime(datestr, "%B %d")
         if extractedDate.tzinfo:
-            temp = temp.replace(tzinfo=gettz("UTC"))
-            temp = temp.astimezone(extractedDate.tzinfo)
+            temp = temp.replace(tzinfo=extractedDate.tzinfo)
 
         if not hasYear:
             temp = temp.replace(year=extractedDate.year)

--- a/lingua_franca/lang/parse_pt.py
+++ b/lingua_franca/lang/parse_pt.py
@@ -28,6 +28,7 @@ from lingua_franca.lang.common_data_pt import _NUMBERS_PT, \
     _MALE_DETERMINANTS_PT, _MALE_ENDINGS_PT, _GENDERS_PT
 from lingua_franca.internal import resolve_resource_file
 from lingua_franca.lang.parse_common import Normalizer
+from lingua_franca.time import now_local
 import json
 import re
 
@@ -286,9 +287,10 @@ def extract_datetime_pt(text, anchorDate=None, default_time=None):
                 minAbs or secOffset != 0
             )
 
-    if text == "" or not anchorDate:
+    if text == "":
         return None
 
+    anchorDate = anchorDate or now_local()
     found = False
     daySpecified = False
     dayOffset = False

--- a/lingua_franca/lang/parse_sv.py
+++ b/lingua_franca/lang/parse_sv.py
@@ -15,6 +15,7 @@
 #
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+from lingua_franca.time import now_local
 from .parse_common import is_numeric, look_for_fractions, Normalizer
 
 
@@ -155,9 +156,10 @@ def extract_datetime_sv(text, anchorDate=None, default_time=None):
                 minAbs or secOffset != 0
             )
 
-    if text == "" or not anchorDate:
+    if text == "":
         return None
 
+    anchorDate = anchorDate or now_local()
     found = False
     daySpecified = False
     dayOffset = False

--- a/lingua_franca/time.py
+++ b/lingua_franca/time.py
@@ -17,16 +17,26 @@ from datetime import datetime
 from dateutil.tz import gettz, tzlocal
 
 
+__default_tz = None
+
+
+def set_default_tz(tz):
+    global __default_tz
+    # TODO tz validation/conversion from string
+    __default_tz = tz
+
+
 def default_timezone():
     """ Get the default timezone
 
-    default system value
+    either a value set by downstream user with
+    lingua_franca.internal.set_default_tz
+    or default system value
 
     Returns:
         (datetime.tzinfo): Definition of the default timezone
     """
-    # Just go with system default timezone
-    return tzlocal()
+    return __default_tz or tzlocal()
 
 
 def now_utc():
@@ -80,3 +90,4 @@ def to_local(dt):
         return dt.astimezone(tz)
     else:
         return dt.replace(tzinfo=gettz("UTC")).astimezone(tz)
+

--- a/lingua_franca/time.py
+++ b/lingua_franca/time.py
@@ -22,7 +22,8 @@ __default_tz = None
 
 def set_default_tz(tz):
     global __default_tz
-    # TODO tz validation/conversion from string
+    if isinstance(tz, str):
+        tz = gettz(tz)
     __default_tz = tz
 
 

--- a/lingua_franca/time.py
+++ b/lingua_franca/time.py
@@ -92,3 +92,17 @@ def to_local(dt):
     else:
         return dt.replace(tzinfo=gettz("UTC")).astimezone(tz)
 
+
+def to_system(dt):
+    """Convert a datetime to the system's local timezone
+
+    Arguments:
+        dt (datetime): A datetime (if no timezone, assumed to be UTC)
+    Returns:
+        (datetime): time converted to the operation system's timezone
+    """
+    tz = tzlocal()
+    if dt.tzinfo:
+        return dt.astimezone(tz)
+    else:
+        return dt.replace(tzinfo=gettz("UTC")).astimezone(tz)

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -18,7 +18,7 @@ from datetime import datetime, timedelta
 
 from lingua_franca import load_language, unload_language, set_default_lang
 from lingua_franca.internal import FunctionNotLocalizedError
-from lingua_franca.time import to_local, default_timezone
+from lingua_franca.time import default_timezone
 from lingua_franca.parse import extract_datetime
 from lingua_franca.parse import extract_duration
 from lingua_franca.parse import extract_number, extract_numbers

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -18,6 +18,7 @@ from datetime import datetime, timedelta
 
 from lingua_franca import load_language, unload_language, set_default_lang
 from lingua_franca.internal import FunctionNotLocalizedError
+from lingua_franca.time import to_local, default_timezone
 from lingua_franca.parse import extract_datetime
 from lingua_franca.parse import extract_duration
 from lingua_franca.parse import extract_number, extract_numbers
@@ -338,7 +339,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_extractdatetime_fractions_en(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 13, 4)  # Tue June 27, 2017 @ 1:04pm
+            date = datetime(2017, 6, 27, 13, 4, tzinfo=default_timezone())  # Tue June 27, 2017 @ 1:04pm
             [extractedDate, leftover] = extract_datetime(text, date)
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")
             return [extractedDate, leftover]
@@ -361,7 +362,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_extractdatetime_en(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 13, 4)  # Tue June 27, 2017 @ 1:04pm
+            date = datetime(2017, 6, 27, 13, 4, tzinfo=default_timezone())  # Tue June 27, 2017 @ 1:04pm
             [extractedDate, leftover] = extract_datetime(text, date)
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")
             return [extractedDate, leftover]
@@ -709,9 +710,9 @@ class TestNormalize(unittest.TestCase):
                     "2017-07-04 22:00:00", "what is weather like night")
 
     def test_extract_ambiguous_time_en(self):
-        morning = datetime(2017, 6, 27, 8, 1, 2)
-        evening = datetime(2017, 6, 27, 20, 1, 2)
-        noonish = datetime(2017, 6, 27, 12, 1, 2)
+        morning = datetime(2017, 6, 27, 8, 1, 2, tzinfo=default_timezone())
+        evening = datetime(2017, 6, 27, 20, 1, 2, tzinfo=default_timezone())
+        noonish = datetime(2017, 6, 27, 12, 1, 2, tzinfo=default_timezone())
         self.assertEqual(
             extract_datetime('feed the fish'), None)
         self.assertEqual(
@@ -726,30 +727,30 @@ class TestNormalize(unittest.TestCase):
             extract_datetime(' '), None)
         self.assertEqual(
             extract_datetime('feed fish at 10 o\'clock', morning)[0],
-            datetime(2017, 6, 27, 10, 0, 0))
+            datetime(2017, 6, 27, 10, 0, 0, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('feed fish at 10 o\'clock', noonish)[0],
-            datetime(2017, 6, 27, 22, 0, 0))
+            datetime(2017, 6, 27, 22, 0, 0, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('feed fish at 10 o\'clock', evening)[0],
-            datetime(2017, 6, 27, 22, 0, 0))
+            datetime(2017, 6, 27, 22, 0, 0, tzinfo=default_timezone()))
 
     def test_extract_date_with_may_I_en(self):
-        now = datetime(2019, 7, 4, 8, 1, 2)
-        may_date = datetime(2019, 5, 2, 10, 11, 20)
+        now = datetime(2019, 7, 4, 8, 1, 2, tzinfo=default_timezone())
+        may_date = datetime(2019, 5, 2, 10, 11, 20, tzinfo=default_timezone())
         self.assertEqual(
             extract_datetime('May I know what time it is tomorrow', now)[0],
-            datetime(2019, 7, 5, 0, 0, 0))
+            datetime(2019, 7, 5, 0, 0, 0, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('May I when 10 o\'clock is', now)[0],
-            datetime(2019, 7, 4, 10, 0, 0))
+            datetime(2019, 7, 4, 10, 0, 0, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('On 24th of may I want a reminder', may_date)[0],
-            datetime(2019, 5, 24, 0, 0, 0))
+            datetime(2019, 5, 24, 0, 0, 0, tzinfo=default_timezone()))
 
     def test_extract_relativedatetime_en(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 10, 1, 2)
+            date = datetime(2017, 6, 27, 10, 1, 2, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date)
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")
             return [extractedDate, leftover]
@@ -820,16 +821,16 @@ class TestNormalize(unittest.TestCase):
                          'half hour')
 
     def test_extract_date_with_number_words(self):
-        now = datetime(2019, 7, 4, 8, 1, 2)
+        now = datetime(2019, 7, 4, 8, 1, 2, tzinfo=default_timezone())
         self.assertEqual(
             extract_datetime('What time will it be in 2 minutes', now)[0],
-            datetime(2019, 7, 4, 8, 3, 2))
+            datetime(2019, 7, 4, 8, 3, 2, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('What time will it be in two minutes', now)[0],
-            datetime(2019, 7, 4, 8, 3, 2))
+            datetime(2019, 7, 4, 8, 3, 2, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('What time will it be in two hundred minutes', now)[0],
-            datetime(2019, 7, 4, 11, 21, 2))
+            datetime(2019, 7, 4, 11, 21, 2, tzinfo=default_timezone()))
 
     def test_spaces(self):
         self.assertEqual(normalize("  this   is  a    test"),

--- a/test/test_parse_ca.py
+++ b/test/test_parse_ca.py
@@ -21,6 +21,7 @@ from lingua_franca.parse import get_gender
 from lingua_franca.parse import extract_datetime
 from lingua_franca.parse import extract_number
 from lingua_franca.parse import normalize
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -178,7 +179,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_extractdatetime_ca(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 0, 0)
+            date = datetime(2017, 6, 27, 0, 0, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date,
                                                          lang="ca")
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")

--- a/test/test_parse_cs.py
+++ b/test/test_parse_cs.py
@@ -25,6 +25,7 @@ from lingua_franca.parse import fuzzy_match
 from lingua_franca.parse import get_gender
 from lingua_franca.parse import match_one
 from lingua_franca.parse import normalize
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -229,7 +230,8 @@ class TestNormalize(unittest.TestCase):
 
     def test_extractdatetime_cs(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 13, 4)  # Tue June 27, 2017 @ 1:04pm
+            # Tue June 27, 2017 @ 1:04pm
+            date = datetime(2017, 6, 27, 13, 4, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date)
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")
             return [extractedDate, leftover]
@@ -588,9 +590,9 @@ class TestNormalize(unittest.TestCase):
                     "2017-07-04 22:00:00", "jaké bude počasí v noci")
 
     def test_extract_ambiguous_time_cs(self):
-        morning = datetime(2017, 6, 27, 8, 1, 2)
-        večer = datetime(2017, 6, 27, 20, 1, 2)
-        noonish = datetime(2017, 6, 27, 12, 1, 2)
+        morning = datetime(2017, 6, 27, 8, 1, 2, tzinfo=default_timezone())
+        večer = datetime(2017, 6, 27, 20, 1, 2, tzinfo=default_timezone())
+        noonish = datetime(2017, 6, 27, 12, 1, 2, tzinfo=default_timezone())
         self.assertEqual(
             extract_datetime('krmení ryb'), None)
         self.assertEqual(
@@ -605,13 +607,13 @@ class TestNormalize(unittest.TestCase):
             extract_datetime(' '), None)
         self.assertEqual(
             extract_datetime('nakrmit ryby v 10 hodin', morning)[0],
-            datetime(2017, 6, 27, 10, 0, 0))
+            datetime(2017, 6, 27, 10, 0, 0, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('nakrmit ryby v 10 hodin', noonish)[0],
-            datetime(2017, 6, 27, 22, 0, 0))
+            datetime(2017, 6, 27, 22, 0, 0, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('nakrmit ryby v 10 hodin', večer)[0],
-            datetime(2017, 6, 27, 22, 0, 0))
+            datetime(2017, 6, 27, 22, 0, 0, tzinfo=default_timezone()))
 
     """
     In Czech is May and may have different format
@@ -631,7 +633,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_extract_relativedatetime_cs(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 10, 1, 2)
+            date = datetime(2017, 6, 27, 10, 1, 2, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date)
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")
             return [extractedDate, leftover]

--- a/test/test_parse_da.py
+++ b/test/test_parse_da.py
@@ -20,6 +20,7 @@ from lingua_franca import load_language, unload_language, set_default_lang
 from lingua_franca.parse import extract_datetime
 from lingua_franca.parse import extract_number
 from lingua_franca.parse import normalize
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -83,7 +84,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_extractdatetime_da(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 0, 0)
+            date = datetime(2017, 6, 27, 0, 0, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date,
                                                          lang="da-dk", )
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")

--- a/test/test_parse_es.py
+++ b/test/test_parse_es.py
@@ -132,7 +132,7 @@ class TestDatetime_es(unittest.TestCase):
         _now = datetime.now()
         relative_year = _now.year if (_now.month == 1 and _now.day < 11) else \
             (_now.year + 1)
-        self.assertEqual(extract_datetime_es("11 ene")[0],
+        self.assertEqual(extract_datetime_es("11 ene", anchorDate=_now)[0],
                          datetime(relative_year, 1, 11))
 
         # test months

--- a/test/test_parse_es.py
+++ b/test/test_parse_es.py
@@ -20,6 +20,7 @@ from lingua_franca import load_language, unload_language, set_default_lang
 from lingua_franca.parse import (normalize, extract_numbers, extract_number,
                                  extract_datetime)
 from lingua_franca.lang.parse_es import extract_datetime_es, is_fractional_es
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -138,30 +139,30 @@ class TestDatetime_es(unittest.TestCase):
         # test months
         self.assertEqual(extract_datetime(
             "11 ene", lang='es', anchorDate=datetime(1998, 1, 1))[0],
-            datetime(1998, 1, 11))
+            datetime(1998, 1, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 feb", lang='es', anchorDate=datetime(1998, 2, 1))[0],
-            datetime(1998, 2, 11))
+            datetime(1998, 2, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 mar", lang='es', anchorDate=datetime(1998, 3, 1))[0],
-            datetime(1998, 3, 11))
+            datetime(1998, 3, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 abr", lang='es', anchorDate=datetime(1998, 4, 1))[0],
-            datetime(1998, 4, 11))
+            datetime(1998, 4, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 may", lang='es', anchorDate=datetime(1998, 5, 1))[0],
-            datetime(1998, 5, 11))
+            datetime(1998, 5, 11, tzinfo=default_timezone()))
         # there is an issue with the months of june through september (below)
         # hay un problema con las meses junio hasta septiembre (lea abajo)
         self.assertEqual(extract_datetime(
             "11 oct", lang='es', anchorDate=datetime(1998, 10, 1))[0],
-            datetime(1998, 10, 11))
+            datetime(1998, 10, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 nov", lang='es', anchorDate=datetime(1998, 11, 1))[0],
-            datetime(1998, 11, 11))
+            datetime(1998, 11, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 dic", lang='es', anchorDate=datetime(1998, 12, 1))[0],
-            datetime(1998, 12, 11))
+            datetime(1998, 12, 11, tzinfo=default_timezone()))
 
         self.assertEqual(extract_datetime("", lang='es'), None)
 
@@ -174,50 +175,51 @@ class TestDatetime_es(unittest.TestCase):
     def test_bugged_output_wastebasket(self):
         self.assertEqual(extract_datetime(
             "11 jun", lang='es', anchorDate=datetime(1998, 6, 1))[0],
-            datetime(1998, 6, 11))
+            datetime(1998, 6, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 junio", lang='es', anchorDate=datetime(1998, 6, 1))[0],
-            datetime(1998, 6, 11))
+            datetime(1998, 6, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 jul", lang='es', anchorDate=datetime(1998, 7, 1))[0],
-            datetime(1998, 7, 11))
+            datetime(1998, 7, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 ago", lang='es', anchorDate=datetime(1998, 8, 1))[0],
-            datetime(1998, 8, 11))
+            datetime(1998, 8, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 sep", lang='es', anchorDate=datetime(1998, 9, 1))[0],
-            datetime(1998, 9, 11))
+            datetime(1998, 9, 11, tzinfo=default_timezone()))
 
         # It's also failing on years
         self.assertEqual(extract_datetime(
-            "11 ago 1998", lang='es')[0], datetime(1998, 8, 11))
+            "11 ago 1998", lang='es')[0],
+                         datetime(1998, 8, 11, tzinfo=default_timezone()))
 
     def test_extract_datetime_relative(self):
         self.assertEqual(extract_datetime(
             "esta noche", anchorDate=datetime(1998, 1, 1),
-            lang='es'), [datetime(1998, 1, 1, 21, 0, 0), 'esta'])
+            lang='es'), [datetime(1998, 1, 1, 21, 0, 0, tzinfo=default_timezone()), 'esta'])
         self.assertEqual(extract_datetime(
             "ayer noche", anchorDate=datetime(1998, 1, 1),
-            lang='es')[0], datetime(1997, 12, 31, 21))
+            lang='es')[0], datetime(1997, 12, 31, 21, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "el noche anteayer", anchorDate=datetime(1998, 1, 1),
-            lang='es')[0], datetime(1997, 12, 30, 21))
+            lang='es')[0], datetime(1997, 12, 30, 21, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "el noche ante ante ayer", anchorDate=datetime(1998, 1, 1),
-            lang='es')[0], datetime(1997, 12, 29, 21))
+            lang='es')[0], datetime(1997, 12, 29, 21, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "mañana por la mañana", anchorDate=datetime(1998, 1, 1),
-            lang='es')[0], datetime(1998, 1, 2, 8))
+            lang='es')[0], datetime(1998, 1, 2, 8, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "ayer por la tarde", anchorDate=datetime(1998, 1, 1),
-            lang='es')[0], datetime(1997, 12, 31, 15))
+            lang='es')[0], datetime(1997, 12, 31, 15, tzinfo=default_timezone()))
 
         self.assertEqual(extract_datetime("hoy 2 de la mañana", lang='es',
                                           anchorDate=datetime(1998, 1, 1))[0],
-                         datetime(1998, 1, 1, 2))
+                         datetime(1998, 1, 1, 2, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime("hoy 2 de la tarde", lang='es',
                                           anchorDate=datetime(1998, 1, 1))[0],
-                         datetime(1998, 1, 1, 14))
+                         datetime(1998, 1, 1, 14, tzinfo=default_timezone()))
 
     def test_extractdatetime_no_time(self):
         """Check that None is returned if no time is found in sentence."""

--- a/test/test_parse_fr.py
+++ b/test/test_parse_fr.py
@@ -18,6 +18,7 @@ from datetime import datetime, time, timedelta
 
 from lingua_franca import load_language, unload_language, set_default_lang
 from lingua_franca.internal import FunctionNotLocalizedError
+from lingua_franca.time import default_timezone
 from lingua_franca.parse import get_gender
 from lingua_franca.parse import extract_datetime
 from lingua_franca.parse import extract_duration
@@ -98,7 +99,7 @@ class TestNormalize_fr(unittest.TestCase):
 
     def test_extractdatetime_fr(self):
         def extractWithFormat_fr(text):
-            date = datetime(2017, 6, 27, 0, 0)
+            date = datetime(2017, 6, 27, 0, 0, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date,
                                                          lang="fr-fr")
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")
@@ -110,7 +111,7 @@ class TestNormalize_fr(unittest.TestCase):
             self.assertEqual(res[1], expected_leftover)
 
         def extractWithFormatDate2_fr(text):
-            date = datetime(2017, 6, 30, 17, 0)
+            date = datetime(2017, 6, 30, 17, 0, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date,
                                                          lang="fr-fr")
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")

--- a/test/test_parse_it.py
+++ b/test/test_parse_it.py
@@ -17,6 +17,7 @@ import unittest
 from datetime import datetime, time
 
 from lingua_franca import load_language, unload_language, set_default_lang
+from lingua_franca.time import default_timezone
 from lingua_franca.parse import get_gender
 from lingua_franca.parse import extract_datetime
 from lingua_franca.parse import extract_number, extract_numbers
@@ -653,28 +654,28 @@ class TestNormalize(unittest.TestCase):
                        '2018-01-14 23:45:00', 'inserire appuntamento')
 
     def test_extract_ambiguous_time_it(self):
-        mattina = datetime(2017, 6, 27, 8, 1, 2)
-        sera = datetime(2017, 6, 27, 20, 1, 2)
-        mezzogiorno = datetime(2017, 6, 27, 12, 1, 2)
+        mattina = datetime(2017, 6, 27, 8, 1, 2, tzinfo=default_timezone())
+        sera = datetime(2017, 6, 27, 20, 1, 2, tzinfo=default_timezone())
+        mezzogiorno = datetime(2017, 6, 27, 12, 1, 2, tzinfo=default_timezone())
         self.assertEqual(
             extract_datetime('dai da mangiare ai pesci alle 10 in punto',
                              anchorDate=mattina, lang='it-it')[0],
-            datetime(2017, 6, 27, 10, 0, 0))
+            datetime(2017, 6, 27, 10, 0, 0, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('dai da mangiare ai pesci alle 10 in punto',
                              mezzogiorno, lang='it-it')[0],
-            datetime(2017, 6, 27, 22, 0, 0))
+            datetime(2017, 6, 27, 22, 0, 0, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('dai da mangiare ai pesci alle 10 in punto',
                              sera, lang='it-it')[0],
-            datetime(2017, 6, 27, 22, 0, 0))
+            datetime(2017, 6, 27, 22, 0, 0, tzinfo=default_timezone()))
 
     def test_extract_relativedatetime_it(self):
         """
         Test cases for relative datetime
         """
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 10, 1, 2)
+            date = datetime(2017, 6, 27, 10, 1, 2, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date,
                                                          lang='it-it')
             extractedDate = extractedDate.strftime('%Y-%m-%d %H:%M:%S')

--- a/test/test_parse_pl.py
+++ b/test/test_parse_pl.py
@@ -18,6 +18,7 @@ from datetime import datetime, timedelta
 
 from lingua_franca import get_default_lang, set_default_lang, \
     load_language, unload_language
+from lingua_franca.time import default_timezone
 from lingua_franca.parse import extract_datetime
 from lingua_franca.parse import extract_duration
 from lingua_franca.parse import extract_number, extract_numbers
@@ -158,7 +159,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_extractdatetime_pl(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 13, 4)  # Tue June 27, 2017 @ 1:04pm
+            date = datetime(2017, 6, 27, 13, 4, tzinfo=default_timezone())  # Tue June 27, 2017 @ 1:04pm
             print(text) # TODO Remove me
             [extractedDate, leftover] = extract_datetime(text, date)
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")
@@ -440,7 +441,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_extract_relativedatetime_pl(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 10, 1, 2)
+            date = datetime(2017, 6, 27, 10, 1, 2, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date)
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")
             return [extractedDate, leftover]

--- a/test/test_parse_pt.py
+++ b/test/test_parse_pt.py
@@ -21,6 +21,7 @@ from lingua_franca.parse import get_gender
 from lingua_franca.parse import extract_datetime
 from lingua_franca.parse import extract_number
 from lingua_franca.parse import normalize
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -152,7 +153,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_extractdatetime_pt(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 0, 0)
+            date = datetime(2017, 6, 27, 0, 0, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date,
                                                          lang="pt")
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
- all datetime extractors now default to `now_local` for anchorDate
- all `localized_function`s now inject a tzinfo in all tz-naive datetime objects passed as arguments
- default tz-info can be set with `lingua_franca.time.set_default_tz`
- tz-info injection can be enabled/disable in `lingua_franca.config`(default: `enabled`)

in what relates to mycroft-core:
- core should set the default timezone when setting language at intent step
- core should expect LF to always return tz-aware objects (in user configured timezone from .conf)