### PR TITLE
Bump version to v0.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("readme.md", "r") as fh:
 
 setup(
     name='lingua_franca',
-    version='0.4.0rc1',
+    version='0.4.1',
     packages=['lingua_franca', 'lingua_franca.lang'],
     url='https://github.com/MycroftAI/lingua-franca',
     license='Apache2.0',


### PR DESCRIPTION
The LF version in `setup.py` was still listed as a release candidate when the `release/v0.4.0 tag` was made. Unfortunately this means that PyPI would consider it v0.4.0rc1 rather than the full 0.4.0. 

This PR bumps the version up a patch number so we can re-tag and have matching versions for PyPI.