### PR TITLE
Add configurable default timezone information

### DIFF
--- a/lingua_franca/config.py
+++ b/lingua_franca/config.py
@@ -1,1 +1,2 @@
 load_langs_on_demand = False
+inject_timezones = True

--- a/lingua_franca/internal.py
+++ b/lingua_franca/internal.py
@@ -467,12 +467,12 @@ def localized_function(run_own_code_on=[type(None)]):
                         kwargs[key] = to_local(value)
                 for idx, value in enumerate(args):
                     if isinstance(value, datetime) and value.tzinfo is None:
-                        args = args[:idx] + (to_local(value),) + args[idx + 1:]
+                        args = (*args[:idx], to_local(value), *args[idx + 1:])
 
             # Check if we're passing a lang as a kwarg
             if 'lang' in kwargs.keys():
                 lang_param = kwargs['lang']
-                if lang_param == None:
+                if lang_param is None:
                     warn(NoneLangWarning)
                     lang_code = get_default_lang()
                 else:
@@ -481,7 +481,7 @@ def localized_function(run_own_code_on=[type(None)]):
             # Check if we're passing a lang as a positional arg
             elif lang_param_index < len(args):
                 lang_param = args[lang_param_index]
-                if lang_param == None:
+                if lang_param is None:
                     warn(NoneLangWarning)
                     lang_code = get_default_lang()
                 elif lang_param in _SUPPORTED_LANGUAGES or \

--- a/lingua_franca/lang/parse_ca.py
+++ b/lingua_franca/lang/parse_ca.py
@@ -19,9 +19,9 @@
     TODO: numbers greater than 999999
     TODO: date time ca
 """
-
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+from lingua_franca.time import now_local
 from lingua_franca.lang.parse_common import is_numeric, look_for_fractions
 from lingua_franca.lang.common_data_ca import _NUMBERS_CA, \
     _FEMALE_DETERMINANTS_CA, _FEMALE_ENDINGS_CA, \
@@ -337,9 +337,10 @@ def extract_datetime_ca(text, anchorDate=None, default_time=None):
                 minAbs or secOffset != 0
             )
 
-    if text == "" or not anchorDate:
+    if text == "":
         return None
 
+    anchorDate = anchorDate or now_local()
     found = False
     daySpecified = False
     dayOffset = False
@@ -995,6 +996,9 @@ def extract_datetime_ca(text, anchorDate=None, default_time=None):
             datestr = datestr.replace(monthsShort[idx], en_month)
 
         temp = datetime.strptime(datestr, "%B %d")
+        if extractedDate.tzinfo:
+            temp = temp.replace(tzinfo=extractedDate.tzinfo)
+
         if not hasYear:
             temp = temp.replace(year=extractedDate.year)
             if extractedDate < temp:

--- a/lingua_franca/lang/parse_cs.py
+++ b/lingua_franca/lang/parse_cs.py
@@ -760,9 +760,10 @@ def extract_datetime_cs(text, anchorDate=None, default_time=None):
                 minAbs or secOffset != 0
             )
 
-    if text == "" or not anchorDate:
+    if text == "":
         return None
 
+    anchorDate = anchorDate or now_local()
     found = False
     daySpecified = False
     dayOffset = False

--- a/lingua_franca/lang/parse_da.py
+++ b/lingua_franca/lang/parse_da.py
@@ -19,6 +19,7 @@ from lingua_franca.lang.parse_common import is_numeric, look_for_fractions, \
     extract_numbers_generic, Normalizer
 from lingua_franca.lang.common_data_da import _DA_NUMBERS
 from lingua_franca.lang.format_da import pronounce_number_da
+from lingua_franca.time import now_local
 
 
 def extract_number_da(text, short_scale=True, ordinals=False):
@@ -141,9 +142,10 @@ def extract_datetime_da(text, anchorDate=None, default_time=None):
                 minAbs or secOffset != 0
             )
 
-    if text == "" or not anchorDate:
+    if text == "":
         return None
 
+    anchorDate = anchorDate or now_local()
     found = False
     daySpecified = False
     dayOffset = False
@@ -707,6 +709,9 @@ def extract_datetime_da(text, anchorDate=None, default_time=None):
             datestr = datestr.replace(monthsShort[idx], en_month)
 
         temp = datetime.strptime(datestr, "%B %d")
+        if extractedDate.tzinfo:
+            temp = temp.replace(tzinfo=extractedDate.tzinfo)
+
         if not hasYear:
             temp = temp.replace(year=extractedDate.year)
             if extractedDate < temp:

--- a/lingua_franca/lang/parse_de.py
+++ b/lingua_franca/lang/parse_de.py
@@ -20,6 +20,8 @@ from lingua_franca.lang.parse_common import is_numeric, look_for_fractions, \
     extract_numbers_generic, Normalizer
 from lingua_franca.lang.common_data_de import _DE_NUMBERS
 from lingua_franca.lang.format_de import pronounce_number_de
+from lingua_franca.time import now_local
+
 
 de_numbers = {
     'null': 0,
@@ -260,9 +262,10 @@ def extract_datetime_de(text, anchorDate=None, default_time=None):
                 minAbs or secOffset != 0
             )
 
-    if text == "" or not anchorDate:
+    if text == "":
         return None
 
+    anchorDate = anchorDate or now_local()
     found = False
     daySpecified = False
     dayOffset = False
@@ -833,6 +836,9 @@ def extract_datetime_de(text, anchorDate=None, default_time=None):
             datestr = datestr.replace(monthsShort[idx], en_month)
 
         temp = datetime.strptime(datestr, "%B %d")
+        if extractedDate.tzinfo:
+            temp = temp.replace(tzinfo=extractedDate.tzinfo)
+
         if not hasYear:
             temp = temp.replace(year=extractedDate.year)
             if extractedDate < temp:

--- a/lingua_franca/lang/parse_en.py
+++ b/lingua_franca/lang/parse_en.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta
 
 from dateutil.relativedelta import relativedelta
 
+from lingua_franca.time import now_local
 from lingua_franca.lang.parse_common import is_numeric, look_for_fractions, \
     invert_dict, ReplaceableNumber, partition_list, tokenize, Token, Normalizer
 from lingua_franca.lang.common_data_en import _ARTICLES_EN, _NUM_STRING_EN, \
@@ -671,8 +672,10 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
                 hrAbs or minOffset != 0 or
                 minAbs or secOffset != 0
             )
+
     if not anchorDate:
-        anchorDate = datetime.now()
+        anchorDate = now_local()
+
     if text == "":
         return None
 

--- a/lingua_franca/lang/parse_es.py
+++ b/lingua_franca/lang/parse_es.py
@@ -15,7 +15,8 @@
 #
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
-from dateutil.tz import gettz
+
+from lingua_franca.time import now_local
 from lingua_franca.lang.format_es import pronounce_number_es
 from lingua_franca.lang.parse_common import *
 from lingua_franca.lang.common_data_es import _ARTICLES_ES, _STRING_NUM_ES
@@ -367,7 +368,7 @@ def extract_datetime_es(text, anchorDate=None, default_time=None):
     if text == "":
         return None
     if anchorDate is None:
-        anchorDate = datetime.now()
+        anchorDate = now_local()
 
     found = False
     daySpecified = False
@@ -1020,17 +1021,18 @@ def extract_datetime_es(text, anchorDate=None, default_time=None):
             datestr = datestr.replace(monthsShort[idx], en_month)
 
         temp = datetime.strptime(datestr, "%B %d")
-        temp = temp.replace(tzinfo=None)
+        if extractedDate.tzinfo:
+            temp = temp.replace(tzinfo=extractedDate.tzinfo)
+        # temp = to_local(temp)
+
         if not hasYear:
             temp = temp.replace(year=extractedDate.year)
 
             if extractedDate < temp:
-                extractedDate = extractedDate.replace(year=int(currentYear),
-                                                      month=int(
-                                                          temp.strftime(
-                                                              "%m")),
-                                                      day=int(temp.strftime(
-                                                          "%d")))
+                extractedDate = extractedDate.replace(
+                    year=int(currentYear),
+                    month=int(temp.strftime("%m")),
+                    day=int(temp.strftime("%d")))
             else:
                 extractedDate = extractedDate.replace(
                     year=int(currentYear) + 1,

--- a/lingua_franca/lang/parse_es.py
+++ b/lingua_franca/lang/parse_es.py
@@ -1023,7 +1023,6 @@ def extract_datetime_es(text, anchorDate=None, default_time=None):
         temp = datetime.strptime(datestr, "%B %d")
         if extractedDate.tzinfo:
             temp = temp.replace(tzinfo=extractedDate.tzinfo)
-        # temp = to_local(temp)
 
         if not hasYear:
             temp = temp.replace(year=extractedDate.year)

--- a/lingua_franca/lang/parse_fr.py
+++ b/lingua_franca/lang/parse_fr.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import re
+from dateutil.tz import gettz
 from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 from lingua_franca.lang.parse_common import is_numeric, look_for_fractions, \
@@ -21,6 +22,8 @@ from lingua_franca.lang.parse_common import is_numeric, look_for_fractions, \
 from lingua_franca.lang.format_fr import pronounce_number_fr
 from lingua_franca.lang.common_data_fr import _ARTICLES_FR, _NUMBERS_FR, \
     _ORDINAL_ENDINGS_FR
+from lingua_franca.time import now_local
+
 
 def extract_duration_fr(text):
     """
@@ -491,9 +494,10 @@ def extract_datetime_fr(text, anchorDate=None, default_time=None):
                 hrOffset != 0 or minOffset != 0 or secOffset != 0
             )
 
-    if text == "" or not anchorDate:
+    if text == "":
         return None
 
+    anchorDate = anchorDate or now_local()
     found = False
     daySpecified = False
     dayOffset = False
@@ -939,6 +943,9 @@ def extract_datetime_fr(text, anchorDate=None, default_time=None):
     if datestr != "":
         if not hasYear:
             temp = datetime.strptime(datestr, "%B %d")
+            if extractedDate.tzinfo:
+                temp = temp.replace(tzinfo=gettz("UTC"))
+                temp = temp.astimezone(extractedDate.tzinfo)
             temp = temp.replace(year=extractedDate.year)
             if extractedDate < temp:
                 extractedDate = extractedDate.replace(year=int(currentYear),

--- a/lingua_franca/lang/parse_hu.py
+++ b/lingua_franca/lang/parse_hu.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from datetime import datetime, timedelta
+from lingua_franca.time import now_local
 from lingua_franca.lang.parse_common import Normalizer
 
 

--- a/lingua_franca/lang/parse_it.py
+++ b/lingua_franca/lang/parse_it.py
@@ -21,6 +21,7 @@
 import collections
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+from lingua_franca.time import now_local
 from lingua_franca.lang.parse_common import is_numeric, look_for_fractions, \
     extract_numbers_generic, Normalizer
 from lingua_franca.lang.format_it import _LONG_SCALE_IT, _SHORT_SCALE_IT, \
@@ -493,9 +494,9 @@ def extract_datetime_it(text, anchorDate=None, default_time=None):
                 month_offset != 0 or day_offset is True or hr_offset != 0 or
                 hr_abs or min_offset != 0 or min_abs or sec_offset != 0)
 
-    if text == '' or not anchorDate:
+    if text == '':
         return None
-
+    anchorDate = anchorDate or now_local()
     found = False
     day_specified = False
     day_offset = False

--- a/lingua_franca/lang/parse_nl.py
+++ b/lingua_franca/lang/parse_nl.py
@@ -24,6 +24,7 @@ from .common_data_nl import _SHORT_ORDINAL_STRING_NL, _ARTICLES_NL, \
     _LONG_SCALE_NL, _MULTIPLIES_LONG_SCALE_NL, _MULTIPLIES_SHORT_SCALE_NL,\
     _NEGATIVES_NL, _SHORT_SCALE_NL, _STRING_LONG_ORDINAL_NL, _STRING_NUM_NL, \
     _STRING_SHORT_ORDINAL_NL, _SUMS_NL
+from lingua_franca.time import now_local
 import re
 
 
@@ -560,9 +561,10 @@ def extract_datetime_nl(text, anchorDate=None, default_time=None):
                 minAbs or secOffset != 0
             )
 
-    if text == "" or not anchorDate:
+    if text == "":
         return None
 
+    anchorDate = anchorDate or now_local()
     found = False
     daySpecified = False
     dayOffset = False

--- a/lingua_franca/lang/parse_pl.py
+++ b/lingua_franca/lang/parse_pl.py
@@ -23,7 +23,7 @@ from lingua_franca.lang.common_data_pl import _NUM_STRING_PL, \
     _SHORT_SCALE_PL, _SHORT_ORDINAL_PL, _FRACTION_STRING_PL, _TIME_UNITS_CONVERSION, \
     _TIME_UNITS_NORMALIZATION, _MONTHS_TO_EN, _DAYS_TO_EN, _ORDINAL_BASE_PL, \
     _ALT_ORDINALS_PL
-
+from lingua_franca.time import now_local
 import re
 
 
@@ -710,9 +710,10 @@ def extract_datetime_pl(string, dateNow=None, default_time=None):
                 minAbs or secOffset != 0
             )
 
-    if string == "" or not dateNow:
+    if string == "":
         return None
 
+    dateNow = dateNow or now_local()
     found = False
     daySpecified = False
     dayOffset = False

--- a/lingua_franca/lang/parse_pt.py
+++ b/lingua_franca/lang/parse_pt.py
@@ -28,6 +28,7 @@ from lingua_franca.lang.common_data_pt import _NUMBERS_PT, \
     _MALE_DETERMINANTS_PT, _MALE_ENDINGS_PT, _GENDERS_PT
 from lingua_franca.internal import resolve_resource_file
 from lingua_franca.lang.parse_common import Normalizer
+from lingua_franca.time import now_local
 import json
 import re
 
@@ -286,9 +287,10 @@ def extract_datetime_pt(text, anchorDate=None, default_time=None):
                 minAbs or secOffset != 0
             )
 
-    if text == "" or not anchorDate:
+    if text == "":
         return None
 
+    anchorDate = anchorDate or now_local()
     found = False
     daySpecified = False
     dayOffset = False
@@ -953,6 +955,9 @@ def extract_datetime_pt(text, anchorDate=None, default_time=None):
             datestr = datestr.replace(monthsShort[idx], en_month)
 
         temp = datetime.strptime(datestr, "%B %d")
+        if extractedDate.tzinfo:
+            temp = temp.replace(tzinfo=extractedDate.tzinfo)
+
         if not hasYear:
             temp = temp.replace(year=extractedDate.year)
             if extractedDate < temp:

--- a/lingua_franca/lang/parse_sv.py
+++ b/lingua_franca/lang/parse_sv.py
@@ -15,6 +15,7 @@
 #
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+from lingua_franca.time import now_local
 from .parse_common import is_numeric, look_for_fractions, Normalizer
 
 
@@ -155,9 +156,10 @@ def extract_datetime_sv(text, anchorDate=None, default_time=None):
                 minAbs or secOffset != 0
             )
 
-    if text == "" or not anchorDate:
+    if text == "":
         return None
 
+    anchorDate = anchorDate or now_local()
     found = False
     daySpecified = False
     dayOffset = False

--- a/lingua_franca/time.py
+++ b/lingua_franca/time.py
@@ -17,16 +17,27 @@ from datetime import datetime
 from dateutil.tz import gettz, tzlocal
 
 
+__default_tz = None
+
+
+def set_default_tz(tz):
+    global __default_tz
+    if isinstance(tz, str):
+        tz = gettz(tz)
+    __default_tz = tz
+
+
 def default_timezone():
     """ Get the default timezone
 
-    default system value
+    either a value set by downstream user with
+    lingua_franca.internal.set_default_tz
+    or default system value
 
     Returns:
         (datetime.tzinfo): Definition of the default timezone
     """
-    # Just go with system default timezone
-    return tzlocal()
+    return __default_tz or tzlocal()
 
 
 def now_utc():
@@ -80,3 +91,4 @@ def to_local(dt):
         return dt.astimezone(tz)
     else:
         return dt.replace(tzinfo=gettz("UTC")).astimezone(tz)
+

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -35,6 +35,7 @@ from lingua_franca.format import nice_duration
 from lingua_franca.format import pronounce_number
 from lingua_franca.format import date_time_format
 from lingua_franca.format import join_list
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -402,8 +403,8 @@ class TestNiceDateFormat(unittest.TestCase):
                     cls.test_config[sub_dir.parts[-1]] = json.loads(f.read())
 
     def test_convert_times(self):
-        dt = datetime.datetime(2017, 1, 31,
-                               13, 22, 3)
+        dt = datetime.datetime(2017, 1, 31, 
+                               13, 22, 3, tzinfo=default_timezone())
 
         # Verify defaults haven't changed
         self.assertEqual(nice_time(dt),
@@ -411,6 +412,7 @@ class TestNiceDateFormat(unittest.TestCase):
 
         self.assertEqual(nice_time(dt),
                          "one twenty two")
+
         self.assertEqual(nice_time(dt, use_ampm=True),
                          "one twenty two p.m.")
         self.assertEqual(nice_time(dt, speech=False),
@@ -428,7 +430,7 @@ class TestNiceDateFormat(unittest.TestCase):
                          "thirteen twenty two")
 
         dt = datetime.datetime(2017, 1, 31,
-                               13, 0, 3)
+                               13, 0, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "one o'clock")
         self.assertEqual(nice_time(dt, use_ampm=True),
@@ -448,7 +450,7 @@ class TestNiceDateFormat(unittest.TestCase):
                          "thirteen hundred")
 
         dt = datetime.datetime(2017, 1, 31,
-                               13, 2, 3)
+                               13, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "one oh two")
         self.assertEqual(nice_time(dt, use_ampm=True),
@@ -468,7 +470,7 @@ class TestNiceDateFormat(unittest.TestCase):
                          "thirteen zero two")
 
         dt = datetime.datetime(2017, 1, 31,
-                               0, 2, 3)
+                               0, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "twelve oh two")
         self.assertEqual(nice_time(dt, use_ampm=True),
@@ -488,7 +490,7 @@ class TestNiceDateFormat(unittest.TestCase):
                          "zero zero zero two")
 
         dt = datetime.datetime(2018, 2, 8,
-                               1, 2, 33)
+                               1, 2, 33, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "one oh two")
         self.assertEqual(nice_time(dt, use_ampm=True),
@@ -508,19 +510,19 @@ class TestNiceDateFormat(unittest.TestCase):
                          "zero one zero two")
 
         dt = datetime.datetime(2017, 1, 31,
-                               12, 15, 9)
+                               12, 15, 9, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "quarter past twelve")
         self.assertEqual(nice_time(dt, use_ampm=True),
                          "quarter past twelve p.m.")
 
         dt = datetime.datetime(2017, 1, 31,
-                               5, 30, 00)
+                               5, 30, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, use_ampm=True),
                          "half past five a.m.")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 45, 00)
+                               1, 45, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "quarter to two")
 
@@ -562,9 +564,11 @@ class TestNiceDateFormat(unittest.TestCase):
                 dp = ast.literal_eval(p['datetime_param'])
                 np = ast.literal_eval(p['now'])
                 dt = datetime.datetime(
-                    dp[0], dp[1], dp[2], dp[3], dp[4], dp[5])
+                    dp[0], dp[1], dp[2], dp[3], dp[4], dp[5],
+                    tzinfo=default_timezone())
                 now = None if not np else datetime.datetime(
-                    np[0], np[1], np[2], np[3], np[4], np[5])
+                    np[0], np[1], np[2], np[3], np[4], np[5],
+                    tzinfo=default_timezone())
                 print('Testing for ' + lang + ' that ' + str(dt) +
                       ' is date time ' + p['assertEqual'])
                 self.assertEqual(
@@ -596,7 +600,7 @@ class TestNiceDateFormat(unittest.TestCase):
         for lang in self.test_config:
             print("Test all years in " + lang)
             for i in range(1, 9999):
-                dt = datetime.datetime(i, 1, 31, 13, 2, 3)
+                dt = datetime.datetime(i, 1, 31, 13, 2, 3, tzinfo=default_timezone())
                 self.assertTrue(len(nice_year(dt, lang=lang)) > 0)
                 # Looking through the date sequence can be helpful
 

--- a/test/test_format_ca.py
+++ b/test/test_format_ca.py
@@ -21,6 +21,7 @@ from lingua_franca import load_language, unload_language, set_default_lang
 from lingua_franca.format import nice_time
 from lingua_franca.format import pronounce_number
 from lingua_franca.lang.format_ca import TimeVariantCA
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -134,7 +135,7 @@ class TestPronounceNumber(unittest.TestCase):
 class TestNiceDateFormat(unittest.TestCase):
     def test_pm(self):
         dt = datetime.datetime(2017, 1, 31,
-                               13, 22, 3)
+                               13, 22, 3, tzinfo=default_timezone())
 
         # Verify defaults haven't changed
         self.assertEqual(nice_time(dt, lang="ca-es"),
@@ -155,7 +156,8 @@ class TestNiceDateFormat(unittest.TestCase):
         self.assertEqual(nice_time(dt, lang="ca", use_24hour=True,
                                    use_ampm=False), "les tretze i vint-i-dos")
 
-        dt = datetime.datetime(2017, 1, 31, 13, 0, 3)
+        dt = datetime.datetime(2017, 1, 31, 
+                               13, 0, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="ca"), "la una en punt")
         self.assertEqual(nice_time(dt, lang="ca", use_ampm=True),
                          "la una en punt de la tarda")
@@ -169,7 +171,8 @@ class TestNiceDateFormat(unittest.TestCase):
         self.assertEqual(nice_time(dt, lang="ca", use_24hour=True,
                                    use_ampm=True), "les tretze")
 
-        dt = datetime.datetime(2017, 1, 31,  13, 2, 3)
+        dt = datetime.datetime(2017, 1, 31, 
+                               13, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="ca", use_24hour=True),
                          "les tretze i dos")
         self.assertEqual(nice_time(dt, lang="ca", use_ampm=True),
@@ -186,7 +189,8 @@ class TestNiceDateFormat(unittest.TestCase):
         self.assertEqual(nice_time(dt, lang="ca", use_24hour=True,
                                    use_ampm=False), "les tretze i dos")
 
-        dt = datetime.datetime(2017, 1, 31, 12, 15, 0)
+        dt = datetime.datetime(2017, 1, 31,
+                               12, 15, 0, tzinfo=default_timezone())
         # Default Watch system
         self.assertEqual(nice_time(dt, lang="ca", use_24hour=True,
                                    use_ampm=False), "les dotze i quinze")
@@ -204,7 +208,8 @@ class TestNiceDateFormat(unittest.TestCase):
                                    use_ampm=False, variant=TimeVariantCA.BELL),
                          "un quart d'una de la tarda")
 
-        dt = datetime.datetime(2017, 1, 31, 00, 14, 0)
+        dt = datetime.datetime(2017, 1, 31,
+                               00, 14, 0, tzinfo=default_timezone())
         # Default Watch system
         self.assertEqual(nice_time(dt, lang="ca", use_24hour=True,
                                    use_ampm=False), "les zero i catorze")
@@ -225,7 +230,7 @@ class TestNiceDateFormat(unittest.TestCase):
 
     def test_midnight(self):
         dt = datetime.datetime(2017, 1, 31,
-                               0, 2, 3)
+                               0, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="ca"),
                          "les dotze i dos")
         self.assertEqual(nice_time(dt, lang="ca", use_ampm=True),
@@ -248,7 +253,7 @@ class TestNiceDateFormat(unittest.TestCase):
 
     def test_midday(self):
         dt = datetime.datetime(2017, 1, 31,
-                               12, 15, 9)
+                               12, 15, 9, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="ca-es"),
                          "les dotze i quinze")
         self.assertEqual(nice_time(dt, lang="ca-es", use_ampm=True),
@@ -274,7 +279,7 @@ class TestNiceDateFormat(unittest.TestCase):
     def test_minutes_to_hour(self):
         # "twenty minutes to midnight"
         dt = datetime.datetime(2017, 1, 31,
-                               19, 40, 49)
+                               19, 40, 49, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="ca-es"),
                          "les set i quaranta")
         self.assertEqual(nice_time(dt, lang="ca-es", use_ampm=True),
@@ -300,39 +305,39 @@ class TestNiceDateFormat(unittest.TestCase):
     def test_minutes_past_hour(self):
         # "quarter past ten"
         dt = datetime.datetime(2017, 1, 31,
-                               1, 15, 00)
+                               1, 15, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="ca-es", use_24hour=True),
                          "la una i quinze")
         self.assertEqual(nice_time(dt, lang="ca-es"),
                          "la una i quinze")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 35, 00)
+                               1, 35, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="ca-es"),
                          "la una i trenta-cinc")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 45, 00)
+                               1, 45, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="ca-es"),
                          "la una i quaranta-cinc")
 
         dt = datetime.datetime(2017, 1, 31,
-                               4, 50, 00)
+                               4, 50, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="ca-es"),
                          "les quatre i cinquanta")
 
         dt = datetime.datetime(2017, 1, 31,
-                               5, 55, 00)
+                               5, 55, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="ca-es"),
                          "les cinc i cinquanta-cinc")
 
         dt = datetime.datetime(2017, 1, 31,
-                               5, 30, 00)
+                               5, 30, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="ca-es", use_ampm=True),
                          "les cinc i trenta de la matinada")
 
         dt = datetime.datetime(2017, 1, 31,
-                               23, 15, 9)
+                               23, 15, 9, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="ca-es", use_24hour=True,
                                    use_ampm=True),
                          "les vint-i-tres i quinze")
@@ -341,7 +346,8 @@ class TestNiceDateFormat(unittest.TestCase):
                          "les onze i quinze de la nit")
 
     def test_variant_strings(self):
-        dt = datetime.datetime(2017, 1, 31, 12, 15, 0)
+        dt = datetime.datetime(2017, 1, 31, 
+                               12, 15, 0, tzinfo=default_timezone())
         # Default variant
         self.assertEqual(nice_time(dt, lang="ca", use_24hour=True,
                                    use_ampm=False, variant="default"),
@@ -350,7 +356,8 @@ class TestNiceDateFormat(unittest.TestCase):
                                    use_ampm=False),
                          "les dotze i quinze")
 
-        dt = datetime.datetime(2017, 1, 31, 00, 14, 0)
+        dt = datetime.datetime(2017, 1, 31, 
+                               00, 14, 0, tzinfo=default_timezone())
         # Spanish-like time system
         self.assertEqual(nice_time(dt, lang="ca", use_24hour=True,
                                    use_ampm=False,

--- a/test/test_format_cs.py
+++ b/test/test_format_cs.py
@@ -13,15 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from lingua_franca.format import join_list
-from lingua_franca.format import date_time_format
-from lingua_franca.format import pronounce_number
-from lingua_franca.format import nice_duration
-from lingua_franca.format import nice_year
-from lingua_franca.format import nice_date_time
-from lingua_franca.format import nice_date
-from lingua_franca.format import nice_time
-from lingua_franca.format import nice_number
+
 import json
 import unittest
 import datetime
@@ -31,6 +23,16 @@ from pathlib import Path
 
 from lingua_franca import get_default_lang, set_default_lang, \
     load_language, unload_language
+from lingua_franca.format import date_time_format
+from lingua_franca.format import join_list
+from lingua_franca.format import nice_date
+from lingua_franca.format import nice_date_time
+from lingua_franca.format import nice_duration
+from lingua_franca.format import nice_number
+from lingua_franca.format import nice_time
+from lingua_franca.format import nice_year
+from lingua_franca.format import pronounce_number
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -375,7 +377,7 @@ class TestNiceDateFormat(unittest.TestCase):
 
     def test_convert_times(self):
         dt = datetime.datetime(2017, 1, 31,
-                               13, 22, 3)
+                               13, 22, 3, tzinfo=default_timezone())
 
         # Verify defaults haven't changed
         self.assertEqual(nice_time(dt),
@@ -400,7 +402,7 @@ class TestNiceDateFormat(unittest.TestCase):
                          "třináct dvacet dva")
 
         dt = datetime.datetime(2017, 1, 31,
-                               13, 0, 3)
+                               13, 0, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, use_24hour=False),
                          "jedna hodin")
         self.assertEqual(nice_time(dt, use_24hour=False, use_ampm=True),
@@ -420,7 +422,7 @@ class TestNiceDateFormat(unittest.TestCase):
                          "třináct sto")
 
         dt = datetime.datetime(2017, 1, 31,
-                               13, 2, 3)
+                               13, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, use_24hour=False),
                          "jedna oh dva")
         self.assertEqual(nice_time(dt, use_24hour=False, use_ampm=True),
@@ -440,7 +442,7 @@ class TestNiceDateFormat(unittest.TestCase):
                          "třináct nula dva")
 
         dt = datetime.datetime(2017, 1, 31,
-                               0, 2, 3)
+                               0, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, use_24hour=False),
                          "dvanáct oh dva")
         self.assertEqual(nice_time(dt, use_24hour=False, use_ampm=True),
@@ -460,7 +462,7 @@ class TestNiceDateFormat(unittest.TestCase):
                          "nula nula nula dva")
 
         dt = datetime.datetime(2018, 2, 8,
-                               1, 2, 33)
+                               1, 2, 33, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, use_24hour=False),
                          "jedna oh dva")
         self.assertEqual(nice_time(dt, use_24hour=False, use_ampm=True),
@@ -480,19 +482,19 @@ class TestNiceDateFormat(unittest.TestCase):
                          "nula jedna nula dva")
 
         dt = datetime.datetime(2017, 1, 31,
-                               12, 15, 9)
+                               12, 15, 9, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, use_24hour=False),
                          "čtvrt po dvanáct")
         self.assertEqual(nice_time(dt, use_24hour=False, use_ampm=True),
                          "čtvrt po dvanáct p.m.")
 
         dt = datetime.datetime(2017, 1, 31,
-                               5, 30, 00)
+                               5, 30, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, use_24hour=False, use_ampm=True),
                          "půl po pět a.m.")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 45, 00)
+                               1, 45, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, use_24hour=False),
                          "třičtvrtě na dva")
 
@@ -505,9 +507,11 @@ class TestNiceDateFormat(unittest.TestCase):
             dp = ast.literal_eval(p['datetime_param'])
             np = ast.literal_eval(p['now'])
             dt = datetime.datetime(
-                dp[0], dp[1], dp[2], dp[3], dp[4], dp[5])
+                dp[0], dp[1], dp[2], dp[3], dp[4], dp[5],
+                tzinfo=default_timezone())
             now = None if not np else datetime.datetime(
-                np[0], np[1], np[2], np[3], np[4], np[5])
+                np[0], np[1], np[2], np[3], np[4], np[5],
+                tzinfo=default_timezone())
             print('Testing for ' + lang + ' that ' + str(dt) +
                     ' is date ' + p['assertEqual'])
             self.assertEqual(p['assertEqual'],
@@ -515,7 +519,7 @@ class TestNiceDateFormat(unittest.TestCase):
             i = i + 1
 
         # test fall back to english !!!Skiped
-        #dt = datetime.datetime(2018, 2, 4, 0, 2, 3)
+        #dt = datetime.datetime(2018, 2, 4, 0, 2, 3, tzinfo=default_timezone())
         # self.assertEqual(nice_date(
         #    dt, lang='invalid', now=datetime.datetime(2018, 2, 4, 0, 2, 3)),
         #    'today')
@@ -523,7 +527,8 @@ class TestNiceDateFormat(unittest.TestCase):
         # test all days in a year for all languages,
         # that some output is produced
         # for lang in self.test_config:
-        for dt in (datetime.datetime(2017, 12, 30, 0, 2, 3) +
+        for dt in (datetime.datetime(2017, 12, 30, 0, 2, 3,
+                   tzinfo=default_timezone()) +
                    datetime.timedelta(n) for n in range(368)):
             self.assertTrue(len(nice_date(dt, lang=lang)) > 0)
 
@@ -536,7 +541,8 @@ class TestNiceDateFormat(unittest.TestCase):
             dp = ast.literal_eval(p['datetime_param'])
             np = ast.literal_eval(p['now'])
             dt = datetime.datetime(
-                dp[0], dp[1], dp[2], dp[3], dp[4], dp[5])
+                dp[0], dp[1], dp[2], dp[3], dp[4], dp[5],
+                tzinfo=default_timezone())
             now = None if not np else datetime.datetime(
                 np[0], np[1], np[2], np[3], np[4], np[5])
             print('Testing for ' + lang + ' that ' + str(dt) +
@@ -557,7 +563,8 @@ class TestNiceDateFormat(unittest.TestCase):
             p = self.test_config[lang]['test_nice_year'][str(i)]
             dp = ast.literal_eval(p['datetime_param'])
             dt = datetime.datetime(
-                dp[0], dp[1], dp[2], dp[3], dp[4], dp[5])
+                dp[0], dp[1], dp[2], dp[3], dp[4], dp[5],
+                tzinfo=default_timezone())
             print('Testing for ' + lang + ' that ' + str(dt) +
                     ' is year ' + p['assertEqual'])
             self.assertEqual(p['assertEqual'], nice_year(
@@ -568,7 +575,8 @@ class TestNiceDateFormat(unittest.TestCase):
         # that some output is produced
         print("Test all years in " + lang)
         for i in range(1, 9999):
-            dt = datetime.datetime(i, 1, 31, 13, 2, 3)
+            dt = datetime.datetime(i, 1, 31, 13, 2, 3,
+                                   tzinfo=default_timezone())
             self.assertTrue(len(nice_year(dt, lang=lang)) > 0)
             # Looking through the date sequence can be helpful
 

--- a/test/test_format_da.py
+++ b/test/test_format_da.py
@@ -23,6 +23,7 @@ from lingua_franca.format import nice_number, nice_time, nice_response, \
 # from lingua_franca.format import pronounce_number
 # # from mycroft_parsers.lang.format_da import nice_response
 from lingua_franca.lang.format_da import pronounce_ordinal_da  # internal to da
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -205,7 +206,7 @@ class TestPronounceNumber(unittest.TestCase):
 #              use_ampm=False):
 class TestNiceDateFormat_da(unittest.TestCase):
     def test_convert_times_da(self):
-        dt = datetime.datetime(2017, 1, 31, 13, 22, 3)
+        dt = datetime.datetime(2017, 1, 31, 13, 22, 3, tzinfo=default_timezone())
 
         self.assertEqual(nice_time(dt, lang="da-dk"),
                          "et toogtyve")
@@ -229,7 +230,7 @@ class TestNiceDateFormat_da(unittest.TestCase):
                                    use_ampm=False),
                          "tretten toogtyve")
 
-        dt = datetime.datetime(2017, 1, 31, 13, 0, 3)
+        dt = datetime.datetime(2017, 1, 31, 13, 0, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="da-dk"), "et")
         self.assertEqual(nice_time(dt, lang="da-dk", use_ampm=True),
                          "et om eftermiddagen")
@@ -251,7 +252,7 @@ class TestNiceDateFormat_da(unittest.TestCase):
                                    use_ampm=False),
                          "tretten")
 
-        dt = datetime.datetime(2017, 1, 31, 13, 2, 3)
+        dt = datetime.datetime(2017, 1, 31, 13, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="da-dk"), "et nul to")
         self.assertEqual(nice_time(dt, lang="da-dk", use_ampm=True),
                          "et nul to om eftermiddagen")
@@ -273,7 +274,7 @@ class TestNiceDateFormat_da(unittest.TestCase):
                                    use_ampm=False),
                          "tretten nul to")
 
-        dt = datetime.datetime(2017, 1, 31, 0, 2, 3)
+        dt = datetime.datetime(2017, 1, 31, 0, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="da-dk"), "tolv nul to")
         self.assertEqual(nice_time(dt, lang="da-dk", use_ampm=True),
                          "tolv nul to om natten")
@@ -295,7 +296,7 @@ class TestNiceDateFormat_da(unittest.TestCase):
                                    use_ampm=False),
                          "nul nul to")
 
-        dt = datetime.datetime(2017, 1, 31, 12, 15, 9)
+        dt = datetime.datetime(2017, 1, 31, 12, 15, 9, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="da-dk"), "tolv femten")
         self.assertEqual(nice_time(dt, lang="da-dk", use_ampm=True),
                          "tolv femten om eftermiddagen")
@@ -317,7 +318,7 @@ class TestNiceDateFormat_da(unittest.TestCase):
                                    use_ampm=False),
                          "tolv femten")
 
-        dt = datetime.datetime(2017, 1, 31, 19, 40, 49)
+        dt = datetime.datetime(2017, 1, 31, 19, 40, 49, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="da-dk"), "syv fyrre")
         self.assertEqual(nice_time(dt, lang="da-dk", use_ampm=True),
                          "syv fyrre om aftenen")
@@ -339,24 +340,24 @@ class TestNiceDateFormat_da(unittest.TestCase):
                                    use_ampm=False),
                          "nitten fyrre")
 
-        dt = datetime.datetime(2017, 1, 31, 1, 15, 00)
+        dt = datetime.datetime(2017, 1, 31, 1, 15, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="da-dk", use_24hour=True),
                          "et femten")
 
-        dt = datetime.datetime(2017, 1, 31, 1, 35, 00)
+        dt = datetime.datetime(2017, 1, 31, 1, 35, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="da-dk"),
                          "et femogtredive")
 
-        dt = datetime.datetime(2017, 1, 31, 1, 45, 00)
+        dt = datetime.datetime(2017, 1, 31, 1, 45, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="da-dk"), "et femogfyrre")
 
-        dt = datetime.datetime(2017, 1, 31, 4, 50, 00)
+        dt = datetime.datetime(2017, 1, 31, 4, 50, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="da-dk"), "fire halvtres")
 
-        dt = datetime.datetime(2017, 1, 31, 5, 55, 00)
+        dt = datetime.datetime(2017, 1, 31, 5, 55, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="da-dk"), "fem femoghalvtres")
 
-        dt = datetime.datetime(2017, 1, 31, 5, 30, 00)
+        dt = datetime.datetime(2017, 1, 31, 5, 30, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="da-dk", use_ampm=True),
                          "fem tredive om morgenen")
 

--- a/test/test_format_de.py
+++ b/test/test_format_de.py
@@ -24,6 +24,7 @@ from lingua_franca.format import pronounce_number
 from lingua_franca.lang.format_de import nice_response_de
 from lingua_franca.lang.format_de import pronounce_ordinal_de
 from lingua_franca.format import join_list
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -219,7 +220,7 @@ class TestNiceDateFormat_de(unittest.TestCase):
 
     def test_convert_times_de(self):
         dt = datetime.datetime(2017, 1, 31,
-                               13, 22, 3)
+                               13, 22, 3, tzinfo=default_timezone())
 
         self.assertEqual(nice_time(dt),
                          "ein Uhr zweiundzwanzig")
@@ -244,7 +245,7 @@ class TestNiceDateFormat_de(unittest.TestCase):
                          "dreizehn Uhr zweiundzwanzig")
 
         dt = datetime.datetime(2017, 1, 31,
-                               13, 0, 3)
+                               13, 0, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "ein Uhr")
         self.assertEqual(nice_time(dt, use_ampm=True),
@@ -268,7 +269,7 @@ class TestNiceDateFormat_de(unittest.TestCase):
                          "dreizehn Uhr")
 
         dt = datetime.datetime(2017, 1, 31,
-                               13, 2, 3)
+                               13, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "ein Uhr zwei")
         self.assertEqual(nice_time(dt, use_ampm=True),
@@ -292,7 +293,7 @@ class TestNiceDateFormat_de(unittest.TestCase):
                          "dreizehn Uhr zwei")
 
         dt = datetime.datetime(2017, 1, 31,
-                               0, 2, 3)
+                               0, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "zwölf Uhr zwei")
         self.assertEqual(nice_time(dt, use_ampm=True),
@@ -316,7 +317,7 @@ class TestNiceDateFormat_de(unittest.TestCase):
                          "null Uhr zwei")
 
         dt = datetime.datetime(2017, 1, 31,
-                               12, 15, 9)
+                               12, 15, 9, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "viertel eins")
         self.assertEqual(nice_time(dt, use_ampm=True),
@@ -340,7 +341,7 @@ class TestNiceDateFormat_de(unittest.TestCase):
                          "zwölf Uhr fünfzehn")
 
         dt = datetime.datetime(2017, 1, 31,
-                               19, 40, 49)
+                               19, 40, 49, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "sieben Uhr vierzig")
         self.assertEqual(nice_time(dt, use_ampm=True),
@@ -364,32 +365,32 @@ class TestNiceDateFormat_de(unittest.TestCase):
                          "neunzehn Uhr vierzig")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 15, 00)
+                               1, 15, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, use_24hour=True),
                          "ein Uhr fünfzehn")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 35, 00)
+                               1, 35, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "ein Uhr fünfunddreißig")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 45, 00)
+                               1, 45, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "dreiviertel zwei")
 
         dt = datetime.datetime(2017, 1, 31,
-                               4, 50, 00)
+                               4, 50, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "vier Uhr fünfzig")
 
         dt = datetime.datetime(2017, 1, 31,
-                               5, 55, 00)
+                               5, 55, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "fünf Uhr fünfundfünfzig")
 
         dt = datetime.datetime(2017, 1, 31,
-                               5, 30, 00)
+                               5, 30, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, use_ampm=True),
                          "halb sechs morgens")
 

--- a/test/test_format_es.py
+++ b/test/test_format_es.py
@@ -21,6 +21,7 @@ from lingua_franca import load_language, unload_language, set_default_lang
 from lingua_franca.format import nice_number
 from lingua_franca.format import nice_time
 from lingua_franca.format import pronounce_number
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -178,7 +179,7 @@ class TestPronounceNumber(unittest.TestCase):
 class TestNiceDateFormat(unittest.TestCase):
     def test_convert_times(self):
         dt = datetime.datetime(2017, 1, 31,
-                               13, 22, 3)
+                               13, 22, 3, tzinfo=default_timezone())
 
         # Verify defaults haven't changed
         self.assertEqual(nice_time(dt, lang="es-es"),
@@ -201,7 +202,7 @@ class TestNiceDateFormat(unittest.TestCase):
                                    use_ampm=False), "las trece veintidós")
 
         dt = datetime.datetime(2017, 1, 31,
-                               13, 0, 3)
+                               13, 0, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="es"),
                          "la una en punto")
         self.assertEqual(nice_time(dt, lang="es", use_ampm=True),
@@ -217,7 +218,7 @@ class TestNiceDateFormat(unittest.TestCase):
         self.assertEqual(nice_time(dt, lang="es", use_24hour=True,
                                    use_ampm=True), "las trece cero cero")
         dt = datetime.datetime(2017, 1, 31,
-                               13, 2, 3)
+                               13, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="es", use_24hour=True),
                          "las trece cero dos")
         self.assertEqual(nice_time(dt, lang="es", use_ampm=True),
@@ -236,7 +237,7 @@ class TestNiceDateFormat(unittest.TestCase):
                                    use_ampm=False), "las trece cero dos")
 
         dt = datetime.datetime(2017, 1, 31,
-                               0, 2, 3)
+                               0, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="es"),
                          "las doce y dos")
         self.assertEqual(nice_time(dt, lang="es", use_ampm=True),
@@ -258,7 +259,7 @@ class TestNiceDateFormat(unittest.TestCase):
                                    use_ampm=False), "las cero cero dos")
 
         dt = datetime.datetime(2017, 1, 31,
-                               12, 15, 9)
+                               12, 15, 9, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="es-es"),
                          "las doce y cuarto")
         self.assertEqual(nice_time(dt, lang="es-es", use_ampm=True),
@@ -282,7 +283,7 @@ class TestNiceDateFormat(unittest.TestCase):
                          "las doce quince")
 
         dt = datetime.datetime(2017, 1, 31,
-                               19, 40, 49)
+                               19, 40, 49, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="es-es"),
                          "las ocho menos veinte")
         self.assertEqual(nice_time(dt, lang="es-es", use_ampm=True),
@@ -306,37 +307,37 @@ class TestNiceDateFormat(unittest.TestCase):
                          "las diecinueve cuarenta")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 15, 00)
+                               1, 15, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="es-es", use_24hour=True),
                          "la una quince")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 35, 00)
+                               1, 35, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="es-es"),
                          "las dos menos veinticinco")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 45, 00)
+                               1, 45, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="es-es"),
                          "las dos menos cuarto")
 
         dt = datetime.datetime(2017, 1, 31,
-                               4, 50, 00)
+                               4, 50, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="es-es"),
                          "las cinco menos diez")
 
         dt = datetime.datetime(2017, 1, 31,
-                               5, 55, 00)
+                               5, 55, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="es-es"),
                          "las seis menos cinco")
 
         dt = datetime.datetime(2017, 1, 31,
-                               5, 30, 00)
+                               5, 30, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="es-es", use_ampm=True),
                          "las cinco y media de la madrugada")
 
         dt = datetime.datetime(2017, 1, 31,
-                               23, 15, 9)
+                               23, 15, 9, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="es-es", use_24hour=True,
                                    use_ampm=True),
                          "las veintitrés quince")

--- a/test/test_format_fr.py
+++ b/test/test_format_fr.py
@@ -20,6 +20,7 @@ from lingua_franca import load_language, unload_language, set_default_lang
 from lingua_franca.format import nice_number
 from lingua_franca.format import nice_time
 from lingua_franca.format import pronounce_number
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -184,7 +185,7 @@ class TestPronounceNumber_fr(unittest.TestCase):
 class TestNiceDateFormat_fr(unittest.TestCase):
     def test_convert_times_fr(self):
         dt = datetime.datetime(2017, 1, 31,
-                               13, 22, 3)
+                               13, 22, 3, tzinfo=default_timezone())
 
         self.assertEqual(nice_time(dt, lang="fr-fr"),
                          "une heure vingt-deux")
@@ -209,7 +210,7 @@ class TestNiceDateFormat_fr(unittest.TestCase):
                          "treize heures vingt-deux")
 
         dt = datetime.datetime(2017, 1, 31,
-                               13, 0, 3)
+                               13, 0, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="fr-fr"),
                          "une heure")
         self.assertEqual(nice_time(dt, lang="fr-fr", use_ampm=True),
@@ -233,7 +234,7 @@ class TestNiceDateFormat_fr(unittest.TestCase):
                          "treize heures")
 
         dt = datetime.datetime(2017, 1, 31,
-                               13, 2, 3)
+                               13, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="fr-fr"),
                          "une heure deux")
         self.assertEqual(nice_time(dt, lang="fr-fr", use_ampm=True),
@@ -257,7 +258,7 @@ class TestNiceDateFormat_fr(unittest.TestCase):
                          "treize heures deux")
 
         dt = datetime.datetime(2017, 1, 31,
-                               0, 2, 3)
+                               0, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="fr-fr"),
                          "minuit deux")
         self.assertEqual(nice_time(dt, lang="fr-fr", use_ampm=True),
@@ -281,7 +282,7 @@ class TestNiceDateFormat_fr(unittest.TestCase):
                          "minuit deux")
 
         dt = datetime.datetime(2017, 1, 31,
-                               12, 15, 9)
+                               12, 15, 9, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="fr-fr"),
                          "midi et quart")
         self.assertEqual(nice_time(dt, lang="fr-fr", use_ampm=True),
@@ -305,7 +306,7 @@ class TestNiceDateFormat_fr(unittest.TestCase):
                          "midi quinze")
 
         dt = datetime.datetime(2017, 1, 31,
-                               19, 40, 49)
+                               19, 40, 49, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="fr-fr"),
                          "huit heures moins vingt")
         self.assertEqual(nice_time(dt, lang="fr-fr", use_ampm=True),
@@ -329,32 +330,32 @@ class TestNiceDateFormat_fr(unittest.TestCase):
                          "dix-neuf heures quarante")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 15, 00)
+                               1, 15, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="fr-fr", use_24hour=True),
                          "une heure quinze")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 35, 00)
+                               1, 35, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="fr-fr"),
                          "deux heures moins vingt-cinq")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 45, 00)
+                               1, 45, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="fr-fr"),
                          "deux heures moins le quart")
 
         dt = datetime.datetime(2017, 1, 31,
-                               4, 50, 00)
+                               4, 50, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="fr-fr"),
                          "cinq heures moins dix")
 
         dt = datetime.datetime(2017, 1, 31,
-                               5, 55, 00)
+                               5, 55, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="fr-fr"),
                          "six heures moins cinq")
 
         dt = datetime.datetime(2017, 1, 31,
-                               5, 30, 00)
+                               5, 30, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="fr-fr", use_ampm=True),
                          "cinq heures et demi du matin")
 

--- a/test/test_format_hu.py
+++ b/test/test_format_hu.py
@@ -21,6 +21,7 @@ from lingua_franca.format import nice_number
 from lingua_franca.format import nice_time
 from lingua_franca.format import pronounce_number
 from lingua_franca.lang.format_hu import pronounce_ordinal_hu
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -208,7 +209,7 @@ class TestPronounceNumber(unittest.TestCase):
 class TestNiceDateFormat_hu(unittest.TestCase):
     def test_convert_times_hu(self):
         dt = datetime.datetime(2017, 1, 31,
-                               13, 22, 3)
+                               13, 22, 3, tzinfo=default_timezone())
 
         self.assertEqual(nice_time(dt, lang="hu-hu"),
                          "egy óra huszonkettő")
@@ -233,7 +234,7 @@ class TestNiceDateFormat_hu(unittest.TestCase):
                          "tizenhárom óra huszonkettő")
 
         dt = datetime.datetime(2017, 1, 31,
-                               13, 0, 3)
+                               13, 0, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="hu-hu"),
                          "egy óra")
         self.assertEqual(nice_time(dt, lang="hu-hu", use_ampm=True),
@@ -257,7 +258,7 @@ class TestNiceDateFormat_hu(unittest.TestCase):
                          "tizenhárom óra")
 
         dt = datetime.datetime(2017, 1, 31,
-                               13, 2, 3)
+                               13, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="hu-hu"),
                          "egy óra kettő")
         self.assertEqual(nice_time(dt, lang="hu-hu", use_ampm=True),
@@ -281,7 +282,7 @@ class TestNiceDateFormat_hu(unittest.TestCase):
                          "tizenhárom óra kettő")
 
         dt = datetime.datetime(2017, 1, 31,
-                               0, 2, 3)
+                               0, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="hu-hu"),
                          "tizenkét óra kettő")
         self.assertEqual(nice_time(dt, lang="hu-hu", use_ampm=True),
@@ -305,7 +306,7 @@ class TestNiceDateFormat_hu(unittest.TestCase):
                          "nulla óra kettő")
 
         dt = datetime.datetime(2017, 1, 31,
-                               12, 15, 9)
+                               12, 15, 9, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="hu-hu"),
                          "tizenkét óra tizenöt")
         self.assertEqual(nice_time(dt, lang="hu-hu", use_ampm=True),
@@ -329,7 +330,7 @@ class TestNiceDateFormat_hu(unittest.TestCase):
                          "tizenkét óra tizenöt")
 
         dt = datetime.datetime(2017, 1, 31,
-                               19, 40, 49)
+                               19, 40, 49, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="hu-hu"),
                          "hét óra negyven")
         self.assertEqual(nice_time(dt, lang="hu-hu", use_ampm=True),
@@ -353,32 +354,32 @@ class TestNiceDateFormat_hu(unittest.TestCase):
                          "tizenkilenc óra negyven")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 15, 00)
+                               1, 15, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="hu-hu", use_24hour=True),
                          "egy óra tizenöt")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 35, 00)
+                               1, 35, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="hu-hu"),
                          "egy óra harmincöt")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 45, 00)
+                               1, 45, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="hu-hu"),
                          "egy óra negyvenöt")
 
         dt = datetime.datetime(2017, 1, 31,
-                               4, 50, 00)
+                               4, 50, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="hu-hu"),
                          "négy óra ötven")
 
         dt = datetime.datetime(2017, 1, 31,
-                               5, 55, 00)
+                               5, 55, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="hu-hu"),
                          "öt óra ötvenöt")
 
         dt = datetime.datetime(2017, 1, 31,
-                               5, 30, 00)
+                               5, 30, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="hu-hu", use_ampm=True),
                          "reggel öt óra harminc")
 

--- a/test/test_format_it.py
+++ b/test/test_format_it.py
@@ -22,6 +22,7 @@ from lingua_franca import load_language, unload_language, set_default_lang
 from lingua_franca.format import nice_number
 from lingua_franca.format import nice_time
 from lingua_franca.format import pronounce_number
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -259,7 +260,7 @@ class TestPronounceNumber(unittest.TestCase):
             "uno milioni, novecento")
 
     def test_convert_times(self):
-        dt = datetime.datetime(2017, 1, 31, 13, 22, 3)
+        dt = datetime.datetime(2017, 1, 31, 13, 22, 3, tzinfo=default_timezone())
 
         # Verify defaults haven't changed
         self.assertEqual(nice_time(dt, lang="it-it"),
@@ -281,22 +282,22 @@ class TestPronounceNumber(unittest.TestCase):
         self.assertEqual(nice_time(dt, lang="it", use_24hour=True,
                                    use_ampm=False), "tredici e ventidue")
         # Verifica fasce orarie use_ampm = True
-        d_time = datetime.datetime(2017, 1, 31, 8, 22, 3)
+        d_time = datetime.datetime(2017, 1, 31, 8, 22, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(d_time, lang="it", use_ampm=True),
                          "otto e ventidue della mattina")
-        d_time = datetime.datetime(2017, 1, 31, 20, 22, 3)
+        d_time = datetime.datetime(2017, 1, 31, 20, 22, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(d_time, lang="it", use_ampm=True),
                          "otto e ventidue della sera")
-        d_time = datetime.datetime(2017, 1, 31, 23, 22, 3)
+        d_time = datetime.datetime(2017, 1, 31, 23, 22, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(d_time, lang="it", use_ampm=True),
                          "undici e ventidue della notte")
-        d_time = datetime.datetime(2017, 1, 31, 00, 00, 3)
+        d_time = datetime.datetime(2017, 1, 31, 00, 00, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(d_time, lang="it", use_ampm=True),
                          "mezzanotte")
-        d_time = datetime.datetime(2017, 1, 31, 12, 00, 3)
+        d_time = datetime.datetime(2017, 1, 31, 12, 00, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(d_time, lang="it", use_ampm=True),
                          "mezzogiorno")
-        dt = datetime.datetime(2017, 1, 31, 13, 0, 3)
+        dt = datetime.datetime(2017, 1, 31, 13, 0, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="it"),
                          "una in punto")
         self.assertEqual(nice_time(dt, lang="it", use_ampm=True),
@@ -314,7 +315,7 @@ class TestPronounceNumber(unittest.TestCase):
         self.assertEqual(nice_time(dt, lang="it", use_24hour=True,
                                    use_ampm=False), "tredici e zerozero")
 
-        dt = datetime.datetime(2017, 1, 31, 13, 2, 3)
+        dt = datetime.datetime(2017, 1, 31, 13, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="it", use_24hour=True),
                          "tredici e zero due")
         self.assertEqual(nice_time(dt, lang="it", use_ampm=True),
@@ -332,7 +333,7 @@ class TestPronounceNumber(unittest.TestCase):
         self.assertEqual(nice_time(dt, lang="it", use_24hour=True,
                                    use_ampm=False), "tredici e zero due")
 
-        dt = datetime.datetime(2017, 1, 31, 0, 2, 3)
+        dt = datetime.datetime(2017, 1, 31, 0, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="it"),
                          "mezzanotte e zero due")
         self.assertEqual(nice_time(dt, lang="it", use_ampm=True),
@@ -351,16 +352,16 @@ class TestPronounceNumber(unittest.TestCase):
         self.assertEqual(nice_time(dt, lang="it", use_24hour=True,
                                    use_ampm=False), "zerozero e zero due")
         # casi particolari
-        d_time = datetime.datetime(2017, 1, 31, 1, 2, 3)
+        d_time = datetime.datetime(2017, 1, 31, 1, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(d_time, lang="it", use_24hour=True,
                                    use_ampm=True), "una e zero due")
-        d_time = datetime.datetime(2017, 1, 31, 2, 2, 3)
+        d_time = datetime.datetime(2017, 1, 31, 2, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(d_time, lang="it", use_24hour=True,
                                    use_ampm=False), "zero due e zero due")
-        d_time = datetime.datetime(2017, 1, 31, 10, 15, 0)
+        d_time = datetime.datetime(2017, 1, 31, 10, 15, 0, tzinfo=default_timezone())
         self.assertEqual(nice_time(d_time, lang="it", use_24hour=False,
                                    use_ampm=False), "dieci e un quarto")
-        d_time = datetime.datetime(2017, 1, 31, 22, 45, 0)
+        d_time = datetime.datetime(2017, 1, 31, 22, 45, 0, tzinfo=default_timezone())
         self.assertEqual(nice_time(d_time, lang="it", use_24hour=False,
                                    use_ampm=False), "dieci e tre quarti")
 

--- a/test/test_format_nl.py
+++ b/test/test_format_nl.py
@@ -22,6 +22,7 @@ from lingua_franca.format import nice_time
 from lingua_franca.format import pronounce_number
 from lingua_franca.lang.format_nl import nice_response_nl
 from lingua_franca.lang.format_nl import pronounce_ordinal_nl
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -199,7 +200,7 @@ class TestPronounceNumber(unittest.TestCase):
 class TestNiceDateFormat_nl(unittest.TestCase):
     def test_convert_times_nl(self):
         dt = datetime.datetime(2017, 1, 31,
-                               13, 22, 3)
+                               13, 22, 3, tzinfo=default_timezone())
 
         self.assertEqual(nice_time(dt, lang="nl-nl"),
                          "tweeentwintig over één")
@@ -224,7 +225,7 @@ class TestNiceDateFormat_nl(unittest.TestCase):
                          "dertien uur tweeentwintig")
 
         dt = datetime.datetime(2017, 1, 31,
-                               13, 0, 3)
+                               13, 0, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="nl-nl"),
                          "één uur")
         self.assertEqual(nice_time(dt, lang="nl-nl", use_ampm=True),
@@ -248,7 +249,7 @@ class TestNiceDateFormat_nl(unittest.TestCase):
                          "dertien uur")
 
         dt = datetime.datetime(2017, 1, 31,
-                               13, 2, 3)
+                               13, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="nl-nl"),
                          "twee over één")
         self.assertEqual(nice_time(dt, lang="nl-nl", use_ampm=True),
@@ -272,7 +273,7 @@ class TestNiceDateFormat_nl(unittest.TestCase):
                          "dertien uur twee")
 
         dt = datetime.datetime(2017, 1, 31,
-                               0, 2, 3)
+                               0, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="nl-nl"),
                          "twee over twaalf")
         self.assertEqual(nice_time(dt, lang="nl-nl", use_ampm=True),
@@ -296,7 +297,7 @@ class TestNiceDateFormat_nl(unittest.TestCase):
                          "nul uur twee")
 
         dt = datetime.datetime(2017, 1, 31,
-                               12, 15, 9)
+                               12, 15, 9, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="nl-nl"),
                          "kwart over twaalf")
         self.assertEqual(nice_time(dt, lang="nl-nl", use_ampm=True),
@@ -320,7 +321,7 @@ class TestNiceDateFormat_nl(unittest.TestCase):
                          "twaalf uur vijftien")
 
         dt = datetime.datetime(2017, 1, 31,
-                               19, 40, 49)
+                               19, 40, 49, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="nl-nl"),
                          "twintig voor acht")
         self.assertEqual(nice_time(dt, lang="nl-nl", use_ampm=True),
@@ -344,32 +345,32 @@ class TestNiceDateFormat_nl(unittest.TestCase):
                          "negentien uur veertig")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 15, 00)
+                               1, 15, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="nl-nl", use_24hour=True),
                          "één uur vijftien")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 35, 00)
+                               1, 35, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="nl-nl"),
                          "vijfentwintig voor twee")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 45, 00)
+                               1, 45, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="nl-nl"),
                          "kwart voor twee")
 
         dt = datetime.datetime(2017, 1, 31,
-                               4, 50, 00)
+                               4, 50, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="nl-nl"),
                          "tien voor vijf")
 
         dt = datetime.datetime(2017, 1, 31,
-                               5, 55, 00)
+                               5, 55, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="nl-nl"),
                          "vijf voor zes")
 
         dt = datetime.datetime(2017, 1, 31,
-                               5, 30, 00)
+                               5, 30, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="nl-nl", use_ampm=True),
                          "half zes 's nachts")
 

--- a/test/test_format_pl.py
+++ b/test/test_format_pl.py
@@ -17,13 +17,14 @@ import unittest
 import datetime
 import sys
 
+from lingua_franca import get_default_lang, set_default_lang, \
+    load_language, unload_language
 from lingua_franca.format import nice_number
 from lingua_franca.format import nice_time
 from lingua_franca.format import nice_duration
 from lingua_franca.format import pronounce_number
+from lingua_franca.time import default_timezone
 
-from lingua_franca import get_default_lang, set_default_lang, \
-    load_language, unload_language
 
 
 def setUpModule():
@@ -269,7 +270,7 @@ class TestPronounceNumber(unittest.TestCase):
 class TestNiceDateFormat(unittest.TestCase):
     def test_convert_times(self):
         dt = datetime.datetime(2017, 1, 31,
-                               13, 22, 3)
+                               13, 22, 3, tzinfo=default_timezone())
 
         self.assertEqual(nice_time(dt),
                          "trzynasta dwadzieścia dwa")
@@ -279,7 +280,7 @@ class TestNiceDateFormat(unittest.TestCase):
                          "trzynasta dwadzieścia dwa")
 
         dt = datetime.datetime(2017, 1, 31,
-                               13, 0, 3)
+                               13, 0, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "trzynasta zero zero")
         self.assertEqual(nice_time(dt, speech=False, use_24hour=True),
@@ -288,7 +289,7 @@ class TestNiceDateFormat(unittest.TestCase):
                          "trzynasta zero zero")
 
         dt = datetime.datetime(2017, 1, 31,
-                               13, 2, 3)
+                               13, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "trzynasta dwa")
         self.assertEqual(nice_time(dt, speech=False, use_24hour=True),
@@ -297,7 +298,7 @@ class TestNiceDateFormat(unittest.TestCase):
                          "trzynasta dwa")
 
         dt = datetime.datetime(2017, 1, 31,
-                               0, 2, 3)
+                               0, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "dwa po północy")
         self.assertEqual(nice_time(dt, speech=False, use_24hour=True),
@@ -306,7 +307,7 @@ class TestNiceDateFormat(unittest.TestCase):
                          "dwa po północy")
 
         dt = datetime.datetime(2018, 2, 8,
-                               1, 2, 33)
+                               1, 2, 33, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "pierwsza dwa")
         self.assertEqual(nice_time(dt, speech=False, use_24hour=True),
@@ -315,12 +316,12 @@ class TestNiceDateFormat(unittest.TestCase):
                          "pierwsza dwa")
 
         dt = datetime.datetime(2017, 1, 31,
-                               12, 15, 9)
+                               12, 15, 9, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "dwunasta piętnaście")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 45, 00)
+                               1, 45, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "pierwsza czterdzieści pięć")
 

--- a/test/test_format_pt.py
+++ b/test/test_format_pt.py
@@ -20,6 +20,7 @@ import datetime
 from lingua_franca import load_language, unload_language, set_default_lang
 from lingua_franca.format import nice_time
 from lingua_franca.format import pronounce_number
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -133,7 +134,7 @@ class TestPronounceNumber(unittest.TestCase):
 class TestNiceDateFormat(unittest.TestCase):
     def test_pm(self):
         dt = datetime.datetime(2017, 1, 31,
-                               13, 22, 3)
+                               13, 22, 3, tzinfo=default_timezone())
 
         # Verify defaults haven't changed
         self.assertEqual(nice_time(dt, lang="pt-pt"),
@@ -156,7 +157,7 @@ class TestNiceDateFormat(unittest.TestCase):
                                    use_ampm=False), "treze e vinte e dois")
 
         dt = datetime.datetime(2017, 1, 31,
-                               13, 0, 3)
+                               13, 0, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="pt"),
                          "uma em ponto")
         self.assertEqual(nice_time(dt, lang="pt", use_ampm=True),
@@ -172,7 +173,7 @@ class TestNiceDateFormat(unittest.TestCase):
         self.assertEqual(nice_time(dt, lang="pt", use_24hour=True,
                                    use_ampm=True), "treze")
         dt = datetime.datetime(2017, 1, 31,
-                               13, 2, 3)
+                               13, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="pt", use_24hour=True),
                          "treze e dois")
         self.assertEqual(nice_time(dt, lang="pt", use_ampm=True),
@@ -192,7 +193,7 @@ class TestNiceDateFormat(unittest.TestCase):
 
     def test_midnight(self):
         dt = datetime.datetime(2017, 1, 31,
-                               0, 2, 3)
+                               0, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="pt"),
                          "meia noite e dois")
         self.assertEqual(nice_time(dt, lang="pt", use_ampm=True),
@@ -215,7 +216,7 @@ class TestNiceDateFormat(unittest.TestCase):
 
     def test_midday(self):
         dt = datetime.datetime(2017, 1, 31,
-                               12, 15, 9)
+                               12, 15, 9, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="pt-pt"),
                          "meio dia e um quarto")
         self.assertEqual(nice_time(dt, lang="pt-pt", use_ampm=True),
@@ -241,7 +242,7 @@ class TestNiceDateFormat(unittest.TestCase):
     def test_minutes_to_hour(self):
         # "twenty minutes to midnight"
         dt = datetime.datetime(2017, 1, 31,
-                               19, 40, 49)
+                               19, 40, 49, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="pt-pt"),
                          "oito menos vinte")
         self.assertEqual(nice_time(dt, lang="pt-pt", use_ampm=True),
@@ -267,39 +268,39 @@ class TestNiceDateFormat(unittest.TestCase):
     def test_minutes_past_hour(self):
         # "quarter past ten"
         dt = datetime.datetime(2017, 1, 31,
-                               1, 15, 00)
+                               1, 15, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="pt-pt", use_24hour=True),
                          "uma e quinze")
         self.assertEqual(nice_time(dt, lang="pt-pt"),
                          "uma e um quarto")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 35, 00)
+                               1, 35, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="pt-pt"),
                          "duas menos vinte e cinco")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 45, 00)
+                               1, 45, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="pt-pt"),
                          "duas menos um quarto")
 
         dt = datetime.datetime(2017, 1, 31,
-                               4, 50, 00)
+                               4, 50, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="pt-pt"),
                          "cinco menos dez")
 
         dt = datetime.datetime(2017, 1, 31,
-                               5, 55, 00)
+                               5, 55, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="pt-pt"),
                          "seis menos cinco")
 
         dt = datetime.datetime(2017, 1, 31,
-                               5, 30, 00)
+                               5, 30, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="pt-pt", use_ampm=True),
                          "cinco e meia da madrugada")
 
         dt = datetime.datetime(2017, 1, 31,
-                               23, 15, 9)
+                               23, 15, 9, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="pt-pt", use_24hour=True,
                                    use_ampm=True),
                          "vinte e três e quinze")

--- a/test/test_format_sl.py
+++ b/test/test_format_sl.py
@@ -20,6 +20,7 @@ import ast
 import sys
 from pathlib import Path
 
+from lingua_franca import get_default_lang, set_default_lang
 from lingua_franca.format import nice_number
 from lingua_franca.format import nice_time
 from lingua_franca.format import nice_date
@@ -29,7 +30,8 @@ from lingua_franca.format import nice_duration
 from lingua_franca.format import pronounce_number
 from lingua_franca.format import date_time_format
 from lingua_franca.format import join_list
-from lingua_franca import get_default_lang, set_default_lang
+from lingua_franca.time import default_timezone
+
 
 NUMBERS_FIXTURE_SL = {
     1.435634: '1.436',
@@ -309,7 +311,7 @@ class TestNiceDateFormat(unittest.TestCase):
 
     def test_convert_times(self):
         dt = datetime.datetime(2017, 1, 31,
-                               13, 22, 3)
+                               13, 22, 3, tzinfo=default_timezone())
 
         # Verify defaults haven't changed
         self.assertEqual(nice_time(dt),
@@ -334,7 +336,7 @@ class TestNiceDateFormat(unittest.TestCase):
                          "trinajst dvaindvajset")
 
         dt = datetime.datetime(2017, 1, 31,
-                               13, 0, 3)
+                               13, 0, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "ena")
         self.assertEqual(nice_time(dt, use_ampm=True),
@@ -354,7 +356,7 @@ class TestNiceDateFormat(unittest.TestCase):
                          "trinajst nič nič")
 
         dt = datetime.datetime(2017, 1, 31,
-                               13, 2, 3)
+                               13, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "dve čez ena")
         self.assertEqual(nice_time(dt, use_ampm=True),
@@ -374,7 +376,7 @@ class TestNiceDateFormat(unittest.TestCase):
                          "trinajst nič dve")
 
         dt = datetime.datetime(2017, 1, 31,
-                               0, 2, 3)
+                               0, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "dve čez dvanajst")
         self.assertEqual(nice_time(dt, use_ampm=True),
@@ -394,21 +396,21 @@ class TestNiceDateFormat(unittest.TestCase):
                          "nič nič dve")
 
         dt = datetime.datetime(2017, 1, 31,
-                               20, 40, 3)
+                               20, 40, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "dvajset do devetih")
         self.assertEqual(nice_time(dt, use_ampm=True),
                          "dvajset do devetih p.m.")
 
         dt = datetime.datetime(2017, 1, 31,
-                               0, 58, 40)
+                               0, 58, 40, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "dve do enih")
         self.assertEqual(nice_time(dt, use_ampm=True),
                          "dve do enih a.m.")
 
         dt = datetime.datetime(2018, 2, 8,
-                               1, 2, 33)
+                               1, 2, 33, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "dve čez ena")
         self.assertEqual(nice_time(dt, use_ampm=True),
@@ -428,29 +430,29 @@ class TestNiceDateFormat(unittest.TestCase):
                          "ena nič dve")
 
         dt = datetime.datetime(2017, 1, 31,
-                               12, 15, 9)
+                               12, 15, 9, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "petnajst čez dvanajst")
         self.assertEqual(nice_time(dt, use_ampm=True),
                          "petnajst čez dvanajst p.m.")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 15, 00)
+                               1, 15, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, use_ampm=True),
                          "petnajst čez ena a.m.")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 45, 00)
+                               1, 45, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, use_ampm=True),
                          "petnajst do dveh a.m.")
 
         dt = datetime.datetime(2017, 1, 31,
-                               5, 30, 00)
+                               5, 30, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, use_ampm=True),
                          "pol šestih a.m.")
 
         dt = datetime.datetime(2017, 1, 31,
-                               1, 45, 00)
+                               1, 45, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt),
                          "petnajst do dveh")
 
@@ -463,9 +465,11 @@ class TestNiceDateFormat(unittest.TestCase):
                 dp = ast.literal_eval(p['datetime_param'])
                 np = ast.literal_eval(p['now'])
                 dt = datetime.datetime(
-                    dp[0], dp[1], dp[2], dp[3], dp[4], dp[5])
+                    dp[0], dp[1], dp[2], dp[3], dp[4], dp[5],
+                    tzinfo=default_timezone())
                 now = None if not np else datetime.datetime(
-                    np[0], np[1], np[2], np[3], np[4], np[5])
+                    np[0], np[1], np[2], np[3], np[4], np[5],
+                    tzinfo=default_timezone())
                 print('Testing for ' + lang + ' that ' + str(dt) +
                       ' is date ' + p['assertEqual'])
                 self.assertEqual(p['assertEqual'],
@@ -481,9 +485,11 @@ class TestNiceDateFormat(unittest.TestCase):
                 dp = ast.literal_eval(p['datetime_param'])
                 np = ast.literal_eval(p['now'])
                 dt = datetime.datetime(
-                    dp[0], dp[1], dp[2], dp[3], dp[4], dp[5])
+                    dp[0], dp[1], dp[2], dp[3], dp[4], dp[5],
+                    tzinfo=default_timezone())
                 now = None if not np else datetime.datetime(
-                    np[0], np[1], np[2], np[3], np[4], np[5])
+                    np[0], np[1], np[2], np[3], np[4], np[5],
+                    tzinfo=default_timezone())
                 print('Testing for ' + lang + ' that ' + str(dt) +
                       ' is date time ' + p['assertEqual'])
                 self.assertEqual(
@@ -502,7 +508,8 @@ class TestNiceDateFormat(unittest.TestCase):
                 p = self.test_config[lang]['test_nice_year'][str(i)]
                 dp = ast.literal_eval(p['datetime_param'])
                 dt = datetime.datetime(
-                    dp[0], dp[1], dp[2], dp[3], dp[4], dp[5])
+                    dp[0], dp[1], dp[2], dp[3], dp[4], dp[5],
+                    tzinfo=default_timezone())
                 print('Testing for ' + lang + ' that ' + str(dt) +
                       ' is year ' + p['assertEqual'])
                 self.assertEqual(p['assertEqual'], nice_year(
@@ -514,7 +521,8 @@ class TestNiceDateFormat(unittest.TestCase):
         for lang in self.test_config:
             print("Test all years in " + lang)
             for i in range(1, 9999):
-                dt = datetime.datetime(i, 1, 31, 13, 2, 3)
+                dt = datetime.datetime(i, 1, 31, 13, 2, 3,
+                                       tzinfo=default_timezone())
                 self.assertTrue(len(nice_year(dt, lang=lang)) > 0)
                 # Looking through the date sequence can be helpful
 

--- a/test/test_format_sv.py
+++ b/test/test_format_sv.py
@@ -19,6 +19,7 @@ import datetime
 from lingua_franca import load_language, unload_language, set_default_lang
 from lingua_franca.format import nice_number, nice_time, pronounce_number
 from lingua_franca.lang.format_sv import pronounce_ordinal_sv
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -205,7 +206,7 @@ class TestPronounceNumber(unittest.TestCase):
 #              use_ampm=False):
 class TestNiceDateFormat_sv(unittest.TestCase):
     def test_convert_times_sv(self):
-        dt = datetime.datetime(2017, 1, 31, 13, 22, 3)
+        dt = datetime.datetime(2017, 1, 31, 13, 22, 3, tzinfo=default_timezone())
 
         self.assertEqual(nice_time(dt, lang="sv-se"),
                          "tjugotvå minuter över ett")
@@ -229,7 +230,7 @@ class TestNiceDateFormat_sv(unittest.TestCase):
                                    use_ampm=False),
                          "tretton tjugotvå")
 
-        dt = datetime.datetime(2017, 1, 31, 13, 0, 3)
+        dt = datetime.datetime(2017, 1, 31, 13, 0, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="sv-se"), "ett")
         self.assertEqual(nice_time(dt, lang="sv-se", use_ampm=True),
                          "ett på eftermiddagen")
@@ -251,7 +252,7 @@ class TestNiceDateFormat_sv(unittest.TestCase):
                                    use_ampm=False),
                          "tretton")
 
-        dt = datetime.datetime(2017, 1, 31, 13, 2, 3)
+        dt = datetime.datetime(2017, 1, 31, 13, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="sv-se"), "två minuter över ett")
         self.assertEqual(nice_time(dt, lang="sv-se", use_ampm=True),
                          "två minuter över ett på eftermiddagen")
@@ -273,7 +274,7 @@ class TestNiceDateFormat_sv(unittest.TestCase):
                                    use_ampm=False),
                          "tretton noll två")
 
-        dt = datetime.datetime(2017, 1, 31, 0, 2, 3)
+        dt = datetime.datetime(2017, 1, 31, 0, 2, 3, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="sv-se"), "två minuter över tolv")
         self.assertEqual(nice_time(dt, lang="sv-se", use_ampm=True),
                          "två minuter över tolv på natten")
@@ -295,7 +296,7 @@ class TestNiceDateFormat_sv(unittest.TestCase):
                                    use_ampm=False),
                          "noll noll två")
 
-        dt = datetime.datetime(2017, 1, 31, 12, 15, 9)
+        dt = datetime.datetime(2017, 1, 31, 12, 15, 9, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="sv-se"), "kvart över tolv")
         self.assertEqual(nice_time(dt, lang="sv-se", use_ampm=True),
                          "kvart över tolv på eftermiddagen")
@@ -317,7 +318,7 @@ class TestNiceDateFormat_sv(unittest.TestCase):
                                    use_ampm=False),
                          "tolv femton")
 
-        dt = datetime.datetime(2017, 1, 31, 19, 40, 49)
+        dt = datetime.datetime(2017, 1, 31, 19, 40, 49, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="sv-se"), "tjugo minuter i åtta")
         self.assertEqual(nice_time(dt, lang="sv-se", use_ampm=True),
                          "tjugo minuter i åtta på kvällen")
@@ -339,24 +340,24 @@ class TestNiceDateFormat_sv(unittest.TestCase):
                                    use_ampm=False),
                          "nitton fyrtio")
 
-        dt = datetime.datetime(2017, 1, 31, 1, 15, 00)
+        dt = datetime.datetime(2017, 1, 31, 1, 15, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="sv-se", use_24hour=True),
                          "ett femton")
 
-        dt = datetime.datetime(2017, 1, 31, 1, 35, 00)
+        dt = datetime.datetime(2017, 1, 31, 1, 35, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="sv-se"),
                          "tjugofem minuter i två")
 
-        dt = datetime.datetime(2017, 1, 31, 1, 45, 00)
+        dt = datetime.datetime(2017, 1, 31, 1, 45, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="sv-se"), "kvart i två")
 
-        dt = datetime.datetime(2017, 1, 31, 4, 50, 00)
+        dt = datetime.datetime(2017, 1, 31, 4, 50, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="sv-se"), "tio i fem")
 
-        dt = datetime.datetime(2017, 1, 31, 5, 55, 00)
+        dt = datetime.datetime(2017, 1, 31, 5, 55, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="sv-se"), "fem i sex")
 
-        dt = datetime.datetime(2017, 1, 31, 5, 30, 00)
+        dt = datetime.datetime(2017, 1, 31, 5, 30, 00, tzinfo=default_timezone())
         self.assertEqual(nice_time(dt, lang="sv-se", use_ampm=True),
                          "halv sex på morgonen")
 

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -18,6 +18,7 @@ from datetime import datetime, timedelta
 
 from lingua_franca import load_language, unload_language, set_default_lang
 from lingua_franca.internal import FunctionNotLocalizedError
+from lingua_franca.time import default_timezone
 from lingua_franca.parse import extract_datetime
 from lingua_franca.parse import extract_duration
 from lingua_franca.parse import extract_number, extract_numbers
@@ -338,7 +339,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_extractdatetime_fractions_en(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 13, 4)  # Tue June 27, 2017 @ 1:04pm
+            date = datetime(2017, 6, 27, 13, 4, tzinfo=default_timezone())  # Tue June 27, 2017 @ 1:04pm
             [extractedDate, leftover] = extract_datetime(text, date)
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")
             return [extractedDate, leftover]
@@ -361,7 +362,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_extractdatetime_en(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 13, 4)  # Tue June 27, 2017 @ 1:04pm
+            date = datetime(2017, 6, 27, 13, 4, tzinfo=default_timezone())  # Tue June 27, 2017 @ 1:04pm
             [extractedDate, leftover] = extract_datetime(text, date)
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")
             return [extractedDate, leftover]
@@ -709,9 +710,9 @@ class TestNormalize(unittest.TestCase):
                     "2017-07-04 22:00:00", "what is weather like night")
 
     def test_extract_ambiguous_time_en(self):
-        morning = datetime(2017, 6, 27, 8, 1, 2)
-        evening = datetime(2017, 6, 27, 20, 1, 2)
-        noonish = datetime(2017, 6, 27, 12, 1, 2)
+        morning = datetime(2017, 6, 27, 8, 1, 2, tzinfo=default_timezone())
+        evening = datetime(2017, 6, 27, 20, 1, 2, tzinfo=default_timezone())
+        noonish = datetime(2017, 6, 27, 12, 1, 2, tzinfo=default_timezone())
         self.assertEqual(
             extract_datetime('feed the fish'), None)
         self.assertEqual(
@@ -726,30 +727,30 @@ class TestNormalize(unittest.TestCase):
             extract_datetime(' '), None)
         self.assertEqual(
             extract_datetime('feed fish at 10 o\'clock', morning)[0],
-            datetime(2017, 6, 27, 10, 0, 0))
+            datetime(2017, 6, 27, 10, 0, 0, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('feed fish at 10 o\'clock', noonish)[0],
-            datetime(2017, 6, 27, 22, 0, 0))
+            datetime(2017, 6, 27, 22, 0, 0, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('feed fish at 10 o\'clock', evening)[0],
-            datetime(2017, 6, 27, 22, 0, 0))
+            datetime(2017, 6, 27, 22, 0, 0, tzinfo=default_timezone()))
 
     def test_extract_date_with_may_I_en(self):
-        now = datetime(2019, 7, 4, 8, 1, 2)
-        may_date = datetime(2019, 5, 2, 10, 11, 20)
+        now = datetime(2019, 7, 4, 8, 1, 2, tzinfo=default_timezone())
+        may_date = datetime(2019, 5, 2, 10, 11, 20, tzinfo=default_timezone())
         self.assertEqual(
             extract_datetime('May I know what time it is tomorrow', now)[0],
-            datetime(2019, 7, 5, 0, 0, 0))
+            datetime(2019, 7, 5, 0, 0, 0, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('May I when 10 o\'clock is', now)[0],
-            datetime(2019, 7, 4, 10, 0, 0))
+            datetime(2019, 7, 4, 10, 0, 0, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('On 24th of may I want a reminder', may_date)[0],
-            datetime(2019, 5, 24, 0, 0, 0))
+            datetime(2019, 5, 24, 0, 0, 0, tzinfo=default_timezone()))
 
     def test_extract_relativedatetime_en(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 10, 1, 2)
+            date = datetime(2017, 6, 27, 10, 1, 2, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date)
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")
             return [extractedDate, leftover]
@@ -820,16 +821,16 @@ class TestNormalize(unittest.TestCase):
                          'half hour')
 
     def test_extract_date_with_number_words(self):
-        now = datetime(2019, 7, 4, 8, 1, 2)
+        now = datetime(2019, 7, 4, 8, 1, 2, tzinfo=default_timezone())
         self.assertEqual(
             extract_datetime('What time will it be in 2 minutes', now)[0],
-            datetime(2019, 7, 4, 8, 3, 2))
+            datetime(2019, 7, 4, 8, 3, 2, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('What time will it be in two minutes', now)[0],
-            datetime(2019, 7, 4, 8, 3, 2))
+            datetime(2019, 7, 4, 8, 3, 2, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('What time will it be in two hundred minutes', now)[0],
-            datetime(2019, 7, 4, 11, 21, 2))
+            datetime(2019, 7, 4, 11, 21, 2, tzinfo=default_timezone()))
 
     def test_spaces(self):
         self.assertEqual(normalize("  this   is  a    test"),

--- a/test/test_parse_ca.py
+++ b/test/test_parse_ca.py
@@ -21,6 +21,7 @@ from lingua_franca.parse import get_gender
 from lingua_franca.parse import extract_datetime
 from lingua_franca.parse import extract_number
 from lingua_franca.parse import normalize
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -178,7 +179,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_extractdatetime_ca(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 0, 0)
+            date = datetime(2017, 6, 27, 0, 0, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date,
                                                          lang="ca")
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")

--- a/test/test_parse_cs.py
+++ b/test/test_parse_cs.py
@@ -25,6 +25,7 @@ from lingua_franca.parse import fuzzy_match
 from lingua_franca.parse import get_gender
 from lingua_franca.parse import match_one
 from lingua_franca.parse import normalize
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -229,7 +230,8 @@ class TestNormalize(unittest.TestCase):
 
     def test_extractdatetime_cs(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 13, 4)  # Tue June 27, 2017 @ 1:04pm
+            # Tue June 27, 2017 @ 1:04pm
+            date = datetime(2017, 6, 27, 13, 4, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date)
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")
             return [extractedDate, leftover]
@@ -588,9 +590,9 @@ class TestNormalize(unittest.TestCase):
                     "2017-07-04 22:00:00", "jaké bude počasí v noci")
 
     def test_extract_ambiguous_time_cs(self):
-        morning = datetime(2017, 6, 27, 8, 1, 2)
-        večer = datetime(2017, 6, 27, 20, 1, 2)
-        noonish = datetime(2017, 6, 27, 12, 1, 2)
+        morning = datetime(2017, 6, 27, 8, 1, 2, tzinfo=default_timezone())
+        večer = datetime(2017, 6, 27, 20, 1, 2, tzinfo=default_timezone())
+        noonish = datetime(2017, 6, 27, 12, 1, 2, tzinfo=default_timezone())
         self.assertEqual(
             extract_datetime('krmení ryb'), None)
         self.assertEqual(
@@ -605,13 +607,13 @@ class TestNormalize(unittest.TestCase):
             extract_datetime(' '), None)
         self.assertEqual(
             extract_datetime('nakrmit ryby v 10 hodin', morning)[0],
-            datetime(2017, 6, 27, 10, 0, 0))
+            datetime(2017, 6, 27, 10, 0, 0, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('nakrmit ryby v 10 hodin', noonish)[0],
-            datetime(2017, 6, 27, 22, 0, 0))
+            datetime(2017, 6, 27, 22, 0, 0, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('nakrmit ryby v 10 hodin', večer)[0],
-            datetime(2017, 6, 27, 22, 0, 0))
+            datetime(2017, 6, 27, 22, 0, 0, tzinfo=default_timezone()))
 
     """
     In Czech is May and may have different format
@@ -631,7 +633,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_extract_relativedatetime_cs(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 10, 1, 2)
+            date = datetime(2017, 6, 27, 10, 1, 2, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date)
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")
             return [extractedDate, leftover]

--- a/test/test_parse_da.py
+++ b/test/test_parse_da.py
@@ -20,6 +20,7 @@ from lingua_franca import load_language, unload_language, set_default_lang
 from lingua_franca.parse import extract_datetime
 from lingua_franca.parse import extract_number
 from lingua_franca.parse import normalize
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -83,7 +84,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_extractdatetime_da(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 0, 0)
+            date = datetime(2017, 6, 27, 0, 0, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date,
                                                          lang="da-dk", )
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")

--- a/test/test_parse_es.py
+++ b/test/test_parse_es.py
@@ -20,6 +20,7 @@ from lingua_franca import load_language, unload_language, set_default_lang
 from lingua_franca.parse import (normalize, extract_numbers, extract_number,
                                  extract_datetime)
 from lingua_franca.lang.parse_es import extract_datetime_es, is_fractional_es
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -132,36 +133,36 @@ class TestDatetime_es(unittest.TestCase):
         _now = datetime.now()
         relative_year = _now.year if (_now.month == 1 and _now.day < 11) else \
             (_now.year + 1)
-        self.assertEqual(extract_datetime_es("11 ene")[0],
+        self.assertEqual(extract_datetime_es("11 ene", anchorDate=_now)[0],
                          datetime(relative_year, 1, 11))
 
         # test months
         self.assertEqual(extract_datetime(
             "11 ene", lang='es', anchorDate=datetime(1998, 1, 1))[0],
-            datetime(1998, 1, 11))
+            datetime(1998, 1, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 feb", lang='es', anchorDate=datetime(1998, 2, 1))[0],
-            datetime(1998, 2, 11))
+            datetime(1998, 2, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 mar", lang='es', anchorDate=datetime(1998, 3, 1))[0],
-            datetime(1998, 3, 11))
+            datetime(1998, 3, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 abr", lang='es', anchorDate=datetime(1998, 4, 1))[0],
-            datetime(1998, 4, 11))
+            datetime(1998, 4, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 may", lang='es', anchorDate=datetime(1998, 5, 1))[0],
-            datetime(1998, 5, 11))
+            datetime(1998, 5, 11, tzinfo=default_timezone()))
         # there is an issue with the months of june through september (below)
         # hay un problema con las meses junio hasta septiembre (lea abajo)
         self.assertEqual(extract_datetime(
             "11 oct", lang='es', anchorDate=datetime(1998, 10, 1))[0],
-            datetime(1998, 10, 11))
+            datetime(1998, 10, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 nov", lang='es', anchorDate=datetime(1998, 11, 1))[0],
-            datetime(1998, 11, 11))
+            datetime(1998, 11, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 dic", lang='es', anchorDate=datetime(1998, 12, 1))[0],
-            datetime(1998, 12, 11))
+            datetime(1998, 12, 11, tzinfo=default_timezone()))
 
         self.assertEqual(extract_datetime("", lang='es'), None)
 
@@ -174,50 +175,51 @@ class TestDatetime_es(unittest.TestCase):
     def test_bugged_output_wastebasket(self):
         self.assertEqual(extract_datetime(
             "11 jun", lang='es', anchorDate=datetime(1998, 6, 1))[0],
-            datetime(1998, 6, 11))
+            datetime(1998, 6, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 junio", lang='es', anchorDate=datetime(1998, 6, 1))[0],
-            datetime(1998, 6, 11))
+            datetime(1998, 6, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 jul", lang='es', anchorDate=datetime(1998, 7, 1))[0],
-            datetime(1998, 7, 11))
+            datetime(1998, 7, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 ago", lang='es', anchorDate=datetime(1998, 8, 1))[0],
-            datetime(1998, 8, 11))
+            datetime(1998, 8, 11, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "11 sep", lang='es', anchorDate=datetime(1998, 9, 1))[0],
-            datetime(1998, 9, 11))
+            datetime(1998, 9, 11, tzinfo=default_timezone()))
 
         # It's also failing on years
         self.assertEqual(extract_datetime(
-            "11 ago 1998", lang='es')[0], datetime(1998, 8, 11))
+            "11 ago 1998", lang='es')[0],
+                         datetime(1998, 8, 11, tzinfo=default_timezone()))
 
     def test_extract_datetime_relative(self):
         self.assertEqual(extract_datetime(
             "esta noche", anchorDate=datetime(1998, 1, 1),
-            lang='es'), [datetime(1998, 1, 1, 21, 0, 0), 'esta'])
+            lang='es'), [datetime(1998, 1, 1, 21, 0, 0, tzinfo=default_timezone()), 'esta'])
         self.assertEqual(extract_datetime(
             "ayer noche", anchorDate=datetime(1998, 1, 1),
-            lang='es')[0], datetime(1997, 12, 31, 21))
+            lang='es')[0], datetime(1997, 12, 31, 21, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "el noche anteayer", anchorDate=datetime(1998, 1, 1),
-            lang='es')[0], datetime(1997, 12, 30, 21))
+            lang='es')[0], datetime(1997, 12, 30, 21, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "el noche ante ante ayer", anchorDate=datetime(1998, 1, 1),
-            lang='es')[0], datetime(1997, 12, 29, 21))
+            lang='es')[0], datetime(1997, 12, 29, 21, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "mañana por la mañana", anchorDate=datetime(1998, 1, 1),
-            lang='es')[0], datetime(1998, 1, 2, 8))
+            lang='es')[0], datetime(1998, 1, 2, 8, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime(
             "ayer por la tarde", anchorDate=datetime(1998, 1, 1),
-            lang='es')[0], datetime(1997, 12, 31, 15))
+            lang='es')[0], datetime(1997, 12, 31, 15, tzinfo=default_timezone()))
 
         self.assertEqual(extract_datetime("hoy 2 de la mañana", lang='es',
                                           anchorDate=datetime(1998, 1, 1))[0],
-                         datetime(1998, 1, 1, 2))
+                         datetime(1998, 1, 1, 2, tzinfo=default_timezone()))
         self.assertEqual(extract_datetime("hoy 2 de la tarde", lang='es',
                                           anchorDate=datetime(1998, 1, 1))[0],
-                         datetime(1998, 1, 1, 14))
+                         datetime(1998, 1, 1, 14, tzinfo=default_timezone()))
 
     def test_extractdatetime_no_time(self):
         """Check that None is returned if no time is found in sentence."""

--- a/test/test_parse_fr.py
+++ b/test/test_parse_fr.py
@@ -18,6 +18,7 @@ from datetime import datetime, time, timedelta
 
 from lingua_franca import load_language, unload_language, set_default_lang
 from lingua_franca.internal import FunctionNotLocalizedError
+from lingua_franca.time import default_timezone
 from lingua_franca.parse import get_gender
 from lingua_franca.parse import extract_datetime
 from lingua_franca.parse import extract_duration
@@ -98,7 +99,7 @@ class TestNormalize_fr(unittest.TestCase):
 
     def test_extractdatetime_fr(self):
         def extractWithFormat_fr(text):
-            date = datetime(2017, 6, 27, 0, 0)
+            date = datetime(2017, 6, 27, 0, 0, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date,
                                                          lang="fr-fr")
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")
@@ -110,7 +111,7 @@ class TestNormalize_fr(unittest.TestCase):
             self.assertEqual(res[1], expected_leftover)
 
         def extractWithFormatDate2_fr(text):
-            date = datetime(2017, 6, 30, 17, 0)
+            date = datetime(2017, 6, 30, 17, 0, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date,
                                                          lang="fr-fr")
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")

--- a/test/test_parse_it.py
+++ b/test/test_parse_it.py
@@ -17,6 +17,7 @@ import unittest
 from datetime import datetime, time
 
 from lingua_franca import load_language, unload_language, set_default_lang
+from lingua_franca.time import default_timezone
 from lingua_franca.parse import get_gender
 from lingua_franca.parse import extract_datetime
 from lingua_franca.parse import extract_number, extract_numbers
@@ -653,28 +654,28 @@ class TestNormalize(unittest.TestCase):
                        '2018-01-14 23:45:00', 'inserire appuntamento')
 
     def test_extract_ambiguous_time_it(self):
-        mattina = datetime(2017, 6, 27, 8, 1, 2)
-        sera = datetime(2017, 6, 27, 20, 1, 2)
-        mezzogiorno = datetime(2017, 6, 27, 12, 1, 2)
+        mattina = datetime(2017, 6, 27, 8, 1, 2, tzinfo=default_timezone())
+        sera = datetime(2017, 6, 27, 20, 1, 2, tzinfo=default_timezone())
+        mezzogiorno = datetime(2017, 6, 27, 12, 1, 2, tzinfo=default_timezone())
         self.assertEqual(
             extract_datetime('dai da mangiare ai pesci alle 10 in punto',
                              anchorDate=mattina, lang='it-it')[0],
-            datetime(2017, 6, 27, 10, 0, 0))
+            datetime(2017, 6, 27, 10, 0, 0, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('dai da mangiare ai pesci alle 10 in punto',
                              mezzogiorno, lang='it-it')[0],
-            datetime(2017, 6, 27, 22, 0, 0))
+            datetime(2017, 6, 27, 22, 0, 0, tzinfo=default_timezone()))
         self.assertEqual(
             extract_datetime('dai da mangiare ai pesci alle 10 in punto',
                              sera, lang='it-it')[0],
-            datetime(2017, 6, 27, 22, 0, 0))
+            datetime(2017, 6, 27, 22, 0, 0, tzinfo=default_timezone()))
 
     def test_extract_relativedatetime_it(self):
         """
         Test cases for relative datetime
         """
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 10, 1, 2)
+            date = datetime(2017, 6, 27, 10, 1, 2, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date,
                                                          lang='it-it')
             extractedDate = extractedDate.strftime('%Y-%m-%d %H:%M:%S')

--- a/test/test_parse_it.py
+++ b/test/test_parse_it.py
@@ -17,11 +17,11 @@ import unittest
 from datetime import datetime, time
 
 from lingua_franca import load_language, unload_language, set_default_lang
-from lingua_franca.time import default_timezone
 from lingua_franca.parse import get_gender
 from lingua_franca.parse import extract_datetime
 from lingua_franca.parse import extract_number, extract_numbers
 from lingua_franca.parse import normalize
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -221,7 +221,7 @@ class TestNormalize(unittest.TestCase):
 
         """
         def extractWithFormat_it(text):
-            date = datetime(2018, 1, 13, 13, 4)  # Sab 13 Gen, 2018 @ 13:04
+            date = datetime(2018, 1, 13, 13, 4, tzinfo=default_timezone())  # Sab 13 Gen, 2018 @ 13:04
             [extractedDate, leftover] = extract_datetime(text, date,
                                                          lang='it-it')
             extractedDate = extractedDate.strftime('%Y-%m-%d %H:%M:%S')
@@ -616,7 +616,7 @@ class TestNormalize(unittest.TestCase):
         """
 
         def extractWithFormat_it(text):
-            date = datetime(2018, 1, 13, 13, 4)  # Sab 13 Gen, 2018 @ 13:04
+            date = datetime(2018, 1, 13, 13, 4, tzinfo=default_timezone())  # Sab 13 Gen, 2018 @ 13:04
             [extractedDate, leftover] = extract_datetime(text, date,
                                                          lang='it-it')
             extractedDate = extractedDate.strftime('%Y-%m-%d %H:%M:%S')

--- a/test/test_parse_nl.py
+++ b/test/test_parse_nl.py
@@ -19,6 +19,7 @@ from datetime import datetime, time, timedelta
 
 from lingua_franca import load_language, set_default_lang, unload_language
 from lingua_franca.parse import extract_datetime, extract_number, normalize, extract_duration
+from lingua_franca.time import default_timezone
 
 
 LANG = "nl-nl"
@@ -81,7 +82,7 @@ class TestParsing(unittest.TestCase):
 
     def test_extractdatetime_nl(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 0, 0)
+            date = datetime(2017, 6, 27, 0, 0, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, anchorDate=date,
                                                          lang=LANG)
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")

--- a/test/test_parse_pl.py
+++ b/test/test_parse_pl.py
@@ -18,6 +18,7 @@ from datetime import datetime, timedelta
 
 from lingua_franca import get_default_lang, set_default_lang, \
     load_language, unload_language
+from lingua_franca.time import default_timezone
 from lingua_franca.parse import extract_datetime
 from lingua_franca.parse import extract_duration
 from lingua_franca.parse import extract_number, extract_numbers
@@ -158,7 +159,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_extractdatetime_pl(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 13, 4)  # Tue June 27, 2017 @ 1:04pm
+            date = datetime(2017, 6, 27, 13, 4, tzinfo=default_timezone())  # Tue June 27, 2017 @ 1:04pm
             print(text) # TODO Remove me
             [extractedDate, leftover] = extract_datetime(text, date)
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")
@@ -440,7 +441,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_extract_relativedatetime_pl(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 10, 1, 2)
+            date = datetime(2017, 6, 27, 10, 1, 2, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date)
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")
             return [extractedDate, leftover]

--- a/test/test_parse_pt.py
+++ b/test/test_parse_pt.py
@@ -21,6 +21,7 @@ from lingua_franca.parse import get_gender
 from lingua_franca.parse import extract_datetime
 from lingua_franca.parse import extract_number
 from lingua_franca.parse import normalize
+from lingua_franca.time import default_timezone
 
 
 def setUpModule():
@@ -152,7 +153,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_extractdatetime_pt(self):
         def extractWithFormat(text):
-            date = datetime(2017, 6, 27, 0, 0)
+            date = datetime(2017, 6, 27, 0, 0, tzinfo=default_timezone())
             [extractedDate, leftover] = extract_datetime(text, date,
                                                          lang="pt")
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
#### Description
Adds configurable default timezone information for use by 

- Default tz-info can be set with `lingua_franca.time.set_default_tz`
- All datetime extractors default to `now_local` for `anchorDate`
- All localized functions now inject a tzinfo in all tz-naive datetime objects passed as arguments. Note tz-naive objects are presumed to be in UTC as there is no perfect answer here. 
  - Note this will also be done on methods that do not explicitly require tzinfo such as `nice_time()`
  - As such projects are encouraged to pass in timezone aware datetime objects where ever possible.
- Timezone info injection can be enabled/disable in lingua_franca.config (default: enabled) 
- Lingua Franca should always return a timezone aware datetime object in the configured default timezone

Extends and replaces PR #180  - squashed commits and fixed failing tests.

#### Type of PR
- [x] Bugfix
- [x] Feature implementation

#### Testing
Unit tests have been updated.