### PR TITLE
Clarify docstring that valid tz won't be mutated

### DIFF
--- a/lingua_franca/parse.py
+++ b/lingua_franca/parse.py
@@ -168,7 +168,7 @@ def extract_datetime(text, anchorDate=None, lang='', default_time=None):
 
     Returns:
         [:obj:`datetime`, :obj:`str`]: 'datetime' is the extracted date
-            as a datetime object in the user's local timezone.
+            as a datetime object in the local timezone.
             'leftover_string' is the original phrase with all date and time
             related keywords stripped out. See examples for further
             clarification


### PR DESCRIPTION
#### Description
Small clarification - returned data will be in the "local timezone" which will be either the timezone of the datetime object passed into the method OR the configured default timezone. With the word "user" included it sounded like the return value would always be in the user's configured default timezone.

#### Type of PR
- [x] Documentation improvements