### PR TITLE
Implement function to tie percent sign to number

### DIFF
--- a/lingua_franca/lang/parse_common.py
+++ b/lingua_franca/lang/parse_common.py
@@ -162,6 +162,28 @@ class Normalizer:
         utterance = " ".join(words)
         return utterance
 
+    @staticmethod
+    def _is_number(string):
+        try:
+            number = float(string)
+        except:
+            return False
+        return True
+
+    def tying_percentage(self, utterance):
+        words = self.tokenize(utterance)
+        output = []
+        for idx, w in enumerate(words):
+            if w.startswith('%') and idx > 0:
+                if self._is_number(output[-1]) is False:
+                    output.append(w)
+                else:
+                    output[-1] += w
+            else:
+                output.append(w)
+        utterance = " ".join(output)
+        return utterance
+
     def normalize(self, utterance="", remove_articles=None):
         # mutations
         if self.should_lowercase:
@@ -186,6 +208,7 @@ class Normalizer:
             utterance = self.remove_stopwords(utterance)
         # remove extra spaces
         utterance = " ".join([w for w in utterance.split(" ") if w])
+        utterance = self.tying_percentage(utterance)
         return utterance
 
 

--- a/test/test_parse_common.py
+++ b/test/test_parse_common.py
@@ -48,3 +48,9 @@ class TestParseCommon(unittest.TestCase):
 
         self.assertEqual(normalizer.normalize('42% is current volume!'),
                          '42% is current volume!')
+
+        self.assertEqual(normalizer.normalize('It takes 12.34% of revenue.'),
+                         'It takes 12.34% of revenue.')
+
+        self.assertEqual(normalizer.normalize('Return on asset is 56.78%.'),
+                         'Return on asset is 56.78%.')

--- a/test/test_parse_common.py
+++ b/test/test_parse_common.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from lingua_franca.lang.parse_common import tokenize, Token
+from lingua_franca.lang.parse_common import Normalizer, tokenize, Token
 
 
 class TestParseCommon(unittest.TestCase):
@@ -33,3 +33,18 @@ class TestParseCommon(unittest.TestCase):
 
         self.assertEqual(tokenize('hashtag #1world'),
                          [Token('hashtag', 0), Token('#1world', 1)])
+
+    def test_normalize(self):
+
+        normalizer = Normalizer()
+        self.assertEqual(normalizer.normalize('Set volume to 50%.'),
+                         'Set volume to 50%.')
+
+        self.assertEqual(normalizer.normalize('I am 100% sure.'), 
+                         'I am 100% sure.')
+
+        self.assertEqual(normalizer.normalize('Is current volume 42%?'),
+                         'Is current volume 42%?')
+
+        self.assertEqual(normalizer.normalize('42% is current volume!'),
+                         '42% is current volume!')


### PR DESCRIPTION
#### Description
Fixes #196 

Adds a function to tie the percent sign (`%`) to the preceding numbers.

#### Type of PR

- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Testing added in `test_parse_common.py`. (`test_normalize()`)