### PR TITLE
fix potential circular import

### DIFF
--- a/lingua_franca/format.py
+++ b/lingua_franca/format.py
@@ -37,9 +37,6 @@ _REGISTERED_FUNCTIONS = ("nice_number",
                          "nice_response",
                          "nice_duration")
 
-populate_localized_function_dict("format", langs=get_active_langs())
-
-
 def _translate_word(name, lang=''):
     """ Helper to get word translations
 
@@ -566,3 +563,5 @@ def nice_response(text, lang=''):
         assertEqual(nice_response_de("10 ^ 2"),
                          "10 hoch 2")
     """
+
+populate_localized_function_dict("format", langs=get_active_langs())

--- a/lingua_franca/parse.py
+++ b/lingua_franca/parse.py
@@ -30,9 +30,6 @@ _REGISTERED_FUNCTIONS = ("extract_numbers",
                          "is_fractional",
                          "is_ordinal")
 
-populate_localized_function_dict("parse", langs=get_active_langs())
-
-
 def fuzzy_match(x: str, against: str) -> float:
     """Perform a 'fuzzy' comparison between two strings.
 
@@ -267,3 +264,5 @@ def is_ordinal(input_str, lang=''):
         (bool) or (float): False if not an ordinal, otherwise the number
         corresponding to the ordinal
     """
+
+populate_localized_function_dict("parse", langs=get_active_langs())

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("readme.md", "r") as fh:
 
 setup(
     name='lingua_franca',
-    version='0.4.2',
+    version='0.4.6',
     packages=['lingua_franca', 'lingua_franca.lang'],
     url='https://github.com/MycroftAI/lingua-franca',
     license='Apache2.0',


### PR DESCRIPTION
Fixes potential circular import during the import-and-crawl phrase of localized function caching, where a localized file attempts to reference its parent. By initializing the rest of the parent file *before* attempting to populate the localized function dictionary, it seems to delay the whole thing (and therefore the import-and-crawl phrase) long enough to avoid the ImportError.

In reality, when the potential error hits, the parent file is still partially initialized. In other words, this could technically still be described as a circular import, but, because Python is Python, does not have the effect of one; whatever the localized file is attempting to reference in its parent, that function will necessarily already have been parsed before the localized function is imported.

This is known to work, because HelloChatterbox ran into the problem, and I've already tested the fix against their code.