### PR TITLE
Add detail on supported durations to extract_duration

### DIFF
--- a/lingua_franca/lang/parse_cs.py
+++ b/lingua_franca/lang/parse_cs.py
@@ -31,10 +31,7 @@ from lingua_franca.time import now_local
 
 
 def generate_plurals_cs(originals):
-    """
-    Return a new set or dict containing the plural form of the original values,
-
-    In English this means all with 's' appended to them.
+    """Return a new set or dict containing the plural form of the original values.
 
     Args:
         originals set(str) or dict(str, any): values to pluralize
@@ -600,8 +597,9 @@ def extract_number_cs(text, short_scale=True, ordinals=False):
 
 
 def extract_duration_cs(text):
-    """
-    Convert an english phrase into a number of seconds
+    """Convert a Czech phrase into a number of seconds.
+
+    The function handles durations from seconds up to days.
 
     Convert things like:
         "10 minute"

--- a/lingua_franca/lang/parse_de.py
+++ b/lingua_franca/lang/parse_de.py
@@ -87,8 +87,10 @@ de_numbers = {
 
 
 def extract_duration_de(text):
-    """
-    Convert an german phrase into a number of seconds
+    """Convert a German phrase into a number of seconds.
+
+    The function handles durations from seconds up to days.
+
     Convert things like:
         "10 Minuten"
         "3 Tage 8 Stunden 10 Minuten und 49 Sekunden"

--- a/lingua_franca/lang/parse_fa.py
+++ b/lingua_franca/lang/parse_fa.py
@@ -121,8 +121,9 @@ _date_units = {
 }
 
 def extract_duration_fa(text):
-    """
-    Convert an english phrase into a number of seconds
+    """Convert a Farsi phrase into a number of seconds.
+
+    The function handles durations from seconds up to days.
 
     Convert things like:
         "10 minute"

--- a/lingua_franca/lang/parse_fr.py
+++ b/lingua_franca/lang/parse_fr.py
@@ -26,16 +26,21 @@ from lingua_franca.time import now_local
 
 
 def extract_duration_fr(text):
-    """
-    Convert an french phrase into a number of seconds
+    """Convert a French phrase into a number of seconds.
+
+    The function handles durations from seconds up to days.
+
     Convert things like:
         "10 minutes"
         "3 jours 8 heures 10 minutes und 49 secondes"
     into an int, representing the total number of seconds.
+
     The words used in the duration will be consumed, and
     the remainder returned.
+
     As an example, "set a timer for 5 minutes" would return
     (300, "set a timer for").
+
     Args:
         text (str): string containing a duration
     Returns:

--- a/lingua_franca/lang/parse_nl.py
+++ b/lingua_franca/lang/parse_nl.py
@@ -434,7 +434,9 @@ def extract_number_nl(text, short_scale=True, ordinals=False):
 
 
 def extract_duration_nl(text):
-    """Convert an english phrase into a number of seconds
+    """Convert an english phrase into a number of seconds.
+
+    The function handles durations from seconds up to days.
 
     Convert things like:
         "10 minute"

--- a/lingua_franca/lang/parse_pl.py
+++ b/lingua_franca/lang/parse_pl.py
@@ -597,8 +597,9 @@ def extract_number_pl(text, short_scale=True, ordinals=False):
 
 
 def extract_duration_pl(text):
-    """
-    Convert an english phrase into a number of seconds
+    """Convert an english phrase into a number of seconds.
+
+    The function handles durations from seconds up to days.
 
     Convert things like:
         "10 minute"

--- a/lingua_franca/parse.py
+++ b/lingua_franca/parse.py
@@ -113,7 +113,9 @@ def extract_number(text, short_scale=True, ordinals=False, lang=''):
 
 @localized_function()
 def extract_duration(text, lang=''):
-    """ Convert an english phrase into a number of seconds
+    """Convert an english phrase into a number of seconds.
+
+    The function handles durations from seconds up to days.
 
     Convert things like:
 


### PR DESCRIPTION
#### Description
Adopting an addition from #202 across all languages with a localized `extract_duration` method. This adds detail on the length of durations supported.

Also some other minor docstring cleanup but not a comprehensive fix of all docstrings.

#### Type of PR
- [x] Documentation improvements

#### Testing
No code changes.

#### CLA
- [x] Yes