### PR TITLE
Fix #224 - parsing 'in 2007'

### DIFF
--- a/lingua_franca/lang/parse_en.py
+++ b/lingua_franca/lang/parse_en.py
@@ -694,7 +694,8 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
     timeQualifiersAM = ['morning']
     timeQualifiersPM = ['afternoon', 'evening', 'night', 'tonight']
     timeQualifiersList = set(timeQualifiersAM + timeQualifiersPM)
-    markers = ['at', 'in', 'on', 'by', 'this', 'around', 'for', 'of', "within"]
+    year_markers = ['in', 'on', 'of']
+    markers = year_markers + ['at', 'by', 'this', 'around', 'for', "within"]
     days = ['monday', 'tuesday', 'wednesday',
             'thursday', 'friday', 'saturday', 'sunday']
     months = ['january', 'february', 'march', 'april', 'may', 'june',
@@ -743,6 +744,10 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
                 yearOffset = multiplier * 100
             elif wordNext == "millennium":
                 yearOffset = multiplier * 1000
+        elif word in year_markers and is_numeric(wordNext) and len(wordNext) == 4:
+            yearOffset = int(wordNext) - int(currentYear)
+            used += 2
+            hasYear = True
         # couple of
         elif word == "2" and wordNext == "of" and \
                 wordNextNext in year_multiples:
@@ -792,7 +797,7 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
             if wordPrev == "the":
                 start -= 1
                 used += 1
-                # parse 5 days, 10 weeks, last week, next week
+        # parse 5 days, 10 weeks, last week, next week
         elif word == "day":
             if wordPrev and wordPrev[0].isdigit():
                 dayOffset += int(wordPrev)
@@ -811,7 +816,7 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
                 dayOffset = -7
                 start -= 1
                 used = 2
-                # parse 10 months, next month, last month
+        # parse 10 months, next month, last month
         elif word == "month" and not fromFlag and wordPrev:
             if wordPrev[0].isdigit():
                 monthOffset = int(wordPrev)
@@ -856,7 +861,7 @@ def extract_datetime_en(text, anchorDate=None, default_time=None):
                 dayOffset -= 7
                 used += 1
                 start -= 1
-                # parse 15 of July, June 20th, Feb 18, 19 of February
+        # parse 15 of July, June 20th, Feb 18, 19 of February
         elif word in months or word in monthsShort and not fromFlag:
             try:
                 m = months.index(word)

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -710,6 +710,11 @@ class TestNormalize(unittest.TestCase):
         testExtract("what's the weather like next tuesday night",
                     "2017-07-04 22:00:00", "what is weather like night")
 
+    def test_extract_date_years(self):
+        date = datetime(2017, 6, 27, tzinfo=default_timezone())  # Tue June 27, 2017
+        self.assertEqual(extract_datetime('in 2007', date)[0],
+            datetime(2007, 6, 27, tzinfo=date.tzinfo))
+
     def test_extract_ambiguous_time_en(self):
         morning = datetime(2017, 6, 27, 8, 1, 2, tzinfo=default_timezone())
         evening = datetime(2017, 6, 27, 20, 1, 2, tzinfo=default_timezone())


### PR DESCRIPTION
#### Description
Fixes #224 - extract_datetime parsing of phrases like "in 2007"

Whilst this isn't ideal behaviour, it is better than returning a time.

This is a port of https://github.com/OpenVoiceOS/ovos-lingua-franca/pull/9

#### Type of PR
- [x] Bugfix

#### Testing
Test added