### PR TITLE
Soften version requirement for python-dateutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-dateutil==2.6.0
+python-dateutil~=2.6.0


### PR DESCRIPTION
#### Description
Allow for system to use newer versions of `python-dateutil` 

Fix #227 

#### Type of PR
- [x] Feature implementation

#### Testing
Automated testing should pass

#### CLA
- [x] Yes