### PR TITLE
Fix CICD job on master: Only update mycroft-core after tag and release

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -67,6 +67,7 @@ jobs:
         repository: MycroftAI/mycroft-core
 
     - name: Update mycroft-core
+      if: needs.tag-release-if-needed.outputs.version
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |


### PR DESCRIPTION
#### Description
This makes sure the update isn't run unless the publishing step was
performed. Currently the Master branch will report CICD failure if no new
version was published, this is now prevented by checking if a version has
been set.

#### Type of PR
- [ x ] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements