### PR TITLE
Bump python-dateutil to latest v2.8.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-dateutil~=2.6.0
+python-dateutil~=2.8.2


### PR DESCRIPTION
#### Description
Just bumps the python-dateutil version to latest v2.8.2

Fixes #234 

#### Testing
Unit tests should continue to pass.